### PR TITLE
Update definitions.rpy due to Syntax error

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -106,7 +106,7 @@ init python:
     for key in ['gf', 'tfw no gf', 'girlfriend', 'my girlfriend', 'you are my girlfriend']:
         monika_topics[key] = 'monika_girlfriend'
     for key in ['waifus', 'waifuism', 'galge', 'romance games', 'dating sims', 'romance movie', 'romance movies']:
-        monika_topics[key] = 'monika_waifu'
+        monika_topics[key] = 'monika_waifus'
         
     def get_pos(channel='music'):
         pos = renpy.music.get_pos(channel=channel)


### PR DESCRIPTION
Syntax error in definitions.rpy, changed "waifu" to "waifus" in order to reflect what's on "script-ch30.rpy", which has "label monika_waifus"