### PR TITLE
Pull 0.3.3 hotfix into master.

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -485,7 +485,7 @@ label ch30_autoload:
         $ config.allow_skipping = True
     else:
         $ config.allow_skipping = False
-    if persistent.current_monikatopic != 0:
+    if renpy.has_label(persistent.current_monikatopic) :
         m "Now, where was I...?"
         pause 2.0
         call expression str(persistent.current_monikatopic) from _call_expression_10


### PR DESCRIPTION
This hotfix addresses a bug where the player might have a bad persistent.current_monikatopic on restart, cause thing game to crash repeatedly.

Now we check that the label exists before trying to jump to it.