### PR TITLE
Fixed save loading and persistent updates in lightweight

### DIFF
--- a/Monika After Story/game/import_ddlc.rpy
+++ b/Monika After Story/game/import_ddlc.rpy
@@ -83,10 +83,12 @@ label import_ddlc_persistent:
         old_persistent=loads(s)
 
         #Bring old_persistent data up to date with current version
+        renpy.call_in_new_context("vv_updates_topics") # init the updates lists
         old_persistent = updateTopicIDs("v030",old_persistent)
         old_persistent = updateTopicIDs("v031",old_persistent)
         old_persistent = updateTopicIDs("v032",old_persistent)
         old_persistent = updateTopicIDs("v033",old_persistent)
+        clearUpdateStructs()
 
         dumpPersistentToFile(old_persistent,basedir + '/old_persistent.txt')
 

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -175,7 +175,7 @@ label splashscreen:
         pause 1.0
 
         #Optional, load a copy of DDLC save data
-        #call import_ddlc_persistent
+        call import_ddlc_persistent
 
         scene white
         with Dissolve(1.5)

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -27,6 +27,12 @@ init -1 python:
 init 9 python:
 
     if persistent.version_number != config.version:
+        renpy.call_in_new_context("vv_updates_topics")
+
+
+# init label for updats_topics
+label vv_updates_topics:
+    python:
 
         # init these dicts
         updates.version_updates = {}


### PR DESCRIPTION
#75 

This creates a new label for init of updates.topics and updates.version_updates. 

The label is called before calling updateTopicIDs in import_ddlc to ensure initalization of these values in the case that a version number hasn't been changed.