### PR TITLE
Fixed repeated topics issue

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -627,7 +627,7 @@ label ch30_monikatopics:
         for key in player_dialogue_ngrams:
             if key in monika_topics:
                 for topic_id in monika_topics[key]:
-                    if topic_id not in possible_topics:
+                    if not renpy.seen_label(topic_id):
                         possible_topics.append(topic_id)
 
         if possible_topics == []: #Therapist answer if no keywords match

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -638,7 +638,7 @@ label ch30_monikatopics:
             persistent.current_monikatopic = renpy.random.choice(possible_topics) #Pick a random topic
 
             allow_dialogue = False
-            renpy.call(persistent.current_monikatopic) #Go to the topic
+            renpy.call_in_new_context(persistent.current_monikatopic) #Go to the topic
             allow_dialogue = True
             #Remove the topic from the random topics list
             if persistent.current_monikatopic in monika_random_topics:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -627,7 +627,7 @@ label ch30_monikatopics:
         for key in player_dialogue_ngrams:
             if key in monika_topics:
                 for topic_id in monika_topics[key]:
-                    if not renpy.seen_label(topic_id):
+                    if topic_id not in possible_topics and not renpy.seen_label(topic_id):
                         possible_topics.append(topic_id)
 
         if possible_topics == []: #Therapist answer if no keywords match


### PR DESCRIPTION
#123 

This occurs in two possible locations:

1. When the player enters a keyword via dialogue box (T), the potential topics are never checked if they had been seen.
2. After a player selects a topic via dialogue box (T), the call to the label is performed via renpy.call. Since each topic has a return, this skips the code post renpy.call, preventing the topic from being removed from monika_random_topics.

Fixes:
1. renpy.seen_label is used prior to adding a topic to potential topics list
2. renpy.call replaced with renpy.call_in_new_context