### PR TITLE
Fixed DDLC topic import issue 

### DIFF
--- a/Monika After Story/game/import_ddlc.rpy
+++ b/Monika After Story/game/import_ddlc.rpy
@@ -187,6 +187,9 @@ label import_ddlc_persistent:
         elif old_persistent._seen_ever is not None:
             persistent._seen_ever=old_persistent._seen_ever
 
+        # after importing/merging _seen_ever, need to redo removeing seen
+        remove_seen_topics()
+
         #Renpy defined list of all seen images
         #Format: dict with (keys) file path (value) Boolean for if seen
         #Example: (u'yuri', u'2m'): True

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5,15 +5,27 @@
 #To allow a topic to come up randomly, append the id to the topics.monika_topics list
 
 define monika_random_topics = []
+define testitem = 0
+
+# we are going to define removing seen topics as a function,
+# as we need to call it dynamically upon import
+init -1 python:
+    def remove_seen_topics():
+        #
+        # Removes seen topics from monika random topics
+        #
+        # ASSUMES:
+        #   monika_random_topics
+        for id in monika_random_topics:
+            if renpy.seen_label(id):
+                monika_random_topics.remove(id)
 
 init 11 python:
     #List of all random topics
     all_random_topics = monika_random_topics
-
+    
     #Remove all previously seen random topics.
-    for id in monika_random_topics:
-        if renpy.seen_label(id):
-            monika_random_topics.remove(id)
+    remove_seen_topics()
 
     #If there are no unseen topics, you can repeat seen ones
     if monika_random_topics==[]:

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -211,8 +211,8 @@ label v031:
 label v030:
     python:
         # the following labels are special cases because of conflicts
-        persistent = removeTopicID("monika_piano")
-        persistent = removeTopicID("monika_college")
+        removeTopicID("monika_piano")
+        removeTopicID("monika_college")
 
         # update!
         persistent = updateTopicIDs("v030")


### PR DESCRIPTION
#128 

On first import of a DDLC file, the seen topics are not removed from `monika_random_topics`. This occurs because the removal of seen topics only occurred at init, while import occurred post-init.

The fix is to refactor removal of seen topics into a function and call this function after merging/importing persistent._seen_ever.