### PR TITLE
Added a music menu, music loop tags, and saving current track in persistent

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -120,7 +120,11 @@ init python:
 
     def select_music():
         # check for open menu
-        if not songs.menu_open:
+        if (not songs.menu_open
+            and renpy.get_screen("history") is None
+            and renpy.get_screen("save") is None
+            and renpy.get_screen("load") is None
+            and renpy.get_screen("preferences") is None):
 
             # music menu label
             renpy.call_in_new_context("display_music_menu")

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -85,8 +85,6 @@ init python:
     import re
     therapist = eliza.eliza()
     process_list = []
-    music_list = ['bgm/m1.ogg', 'bgm/credits.ogg', 'bgm/monika-end.ogg', 'bgm/5_monika.ogg', 'bgm/d.ogg']
-    trackNo = 0
     currentuser = ""
     if renpy.windows:
         try:
@@ -109,14 +107,30 @@ init python:
         pass
 
     #Define new functions
+    def play_song(song):
+        #
+        # literally just plays a song onto the music channel
+        #
+        # IN:
+        #   song - song to play
+        renpy.music.play(song,channel="music",loop=True,synchro_start=True)
+
     def show_dialogue_box():
         renpy.call_in_new_context('ch30_monikatopics')
 
-    def next_track():
-        #This advances through a list of music choices instead of the previous if-else
-        global trackNo
-        trackNo = (trackNo + 1) % len(music_list)
-        renpy.music.play(music_list[trackNo], channel='music', loop=True)
+    def select_music():
+        # check for open menu
+        if not songs.menu_open:
+
+            # music menu label
+            renpy.call_in_new_context("display_music_menu")
+
+            # workaround to handle new context 
+            if songs.selected_track != songs.current_track:
+                play_song(songs.selected_track)
+                songs.current_track = songs.selected_track
+                persistent.current_track = songs.current_track
+
 
     def start_pong():
         renpy.call_in_new_context('game_pong')
@@ -314,7 +328,7 @@ label ch30_main:
     $ config.keymap["play_pong"] = ["p"]
     # Define what those actions call
     $ config.underlay.append(renpy.Keymap(open_dialogue=show_dialogue_box))
-    $ config.underlay.append(renpy.Keymap(change_music=next_track))
+    $ config.underlay.append(renpy.Keymap(change_music=select_music))
     $ config.underlay.append(renpy.Keymap(play_pong=start_pong))
     jump ch30_loop
 
@@ -445,7 +459,12 @@ label ch30_autoload:
                 pos (935,200)
             show monika_bg
             show monika_bg_highlight
-    play music m1 loop
+    #play music m1 loop
+    python:
+        if persistent.current_track is not None:
+            play_song(persistent.current_track)
+        else:
+            play_song(songs.current_track) # default 
     window auto
     $ elapsed = days_passed()
     #Block for anniversary events
@@ -502,7 +521,7 @@ label ch30_autoload:
     $ config.keymap["play_pong"] = ["p"]
     # Define what those actions call
     $ config.underlay.append(renpy.Keymap(open_dialogue=show_dialogue_box))
-    $ config.underlay.append(renpy.Keymap(change_music=next_track))
+    $ config.underlay.append(renpy.Keymap(change_music=select_music))
     $ config.underlay.append(renpy.Keymap(play_pong=start_pong))
     jump ch30_loop
 

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -1,0 +1,103 @@
+# Module that handles the music selection screen
+# we start with zz to ensure this loads LAST
+#
+
+# music inits first, so the screen can be made well
+init -1 python in songs:
+
+    # defaults
+    current_track = "bgm/m1.ogg"
+    selected_track = current_track
+    menu_open = False
+
+    # SONGS:
+    # if you want to add a song, add it to this list as a tuple, where:
+    # [0] -> Title of song
+    # [1] -> Path to song
+    music_choices = list()
+    music_choices.append(("Just Monika","bgm/m1.ogg"))
+    music_choices.append(("Your Reality","bgm/credits.ogg"))
+    music_choices.append(("I Still Love You","bgm/monika-end.ogg"))
+    music_choices.append(("Okay, Everyone! (Monika)","<loop 4.444>bgm/5_monika.ogg"))
+    music_choices.append(("Surprise!","<loop 36.782>bgm/d.ogg"))
+
+
+# MUSIC MENU ##################################################################
+# This is the music selection menu
+###############################################################################
+
+# here we are copying game_menu's layout
+
+#style music_menu_outer_frame is empty
+#style music_menu_navigation_frame is empty
+#style music_menu_content_frame is empty
+#style music_menu_viewport is gui_viewport
+#style music_menu_side is gui_side
+#style music_menu_scrollbar is gui_vscrollbar
+
+#style music_menu_label is gui_label
+#style music_menu_label_text is gui_label_text
+
+#style music_menu_return_button is navigation_button
+style music_menu_return_button_text is navigation_button_text
+
+style music_menu_outer_frame is game_menu_outer_frame
+style music_menu_navigation_frame is game_menu_navigation_frame
+style music_menu_content_frame is game_menu_content_frame
+style music_menu_viewport is game_menu_viewport
+style music_menu_side is game_menu_side
+style music_menu_label is game_menu_label
+style music_menu_label_text is game_menu_label_text
+
+style music_menu_return_button is return_button
+
+screen music_menu():
+    modal True
+
+    zorder 200
+
+    style_prefix "music_menu"
+
+    frame:
+        style "music_menu_outer_frame"
+
+        hbox:
+            
+            frame:
+                style "music_menu_navigation_frame"
+
+            frame:
+                style "music_menu_content_frame"
+
+                transclude
+
+    # this part copied from navigation menu
+    vbox:
+        style_prefix "navigation"
+
+        xpos gui.navigation_xpos
+        yalign 0.8
+        spacing gui.navigation_spacing
+
+        # wonderful loop so we can dynamically add songs
+        $ import store.songs as songs
+        for name,song in songs.music_choices:
+            textbutton _(name) action [SetField(songs,"selected_track",song), Return()]
+
+    textbutton _("Return"):
+        style "music_menu_return_button"
+        action Return()
+
+    label "Music Menu"
+
+# sets locks and calls hte appropriate screen
+label display_music_menu:
+    # set var so we can block multiple music menus
+    python:
+        import store.songs as songs
+        songs.menu_open = True
+
+    call screen music_menu
+
+    $ songs.menu_open = False
+    return


### PR DESCRIPTION
#24 #109 

#109 isn't a major bug, so I've included it here as a next-release since the changes made to music affect how this issue is fixed. These fixes are very simple (adding loop tags), so a bugfix version can be done in like a minute if desired.

Some key points about the music menu:
- the music menu can be accessed by pressing "m" and allows the user to click a song to play
- the menu is generated dynamically, so adding songs is simple as adding to a list (`music_choices`)
- the menu cannot be opened while the game menu (pause menu) is open
- the menu cannot be opened again while the menu is already open
- the menu inherits all its properties from game_menu
- the menu copies code from both game_menu and navigation 

Check issue #24 for a visual of how the music menu looks.

I also added the ability for the current track to be saved in persistent, so upon a restart, the current music continues playing.

In addition, I've named Sayonara as "Surprise!" just for fun. Feel free to rename it properly in the actual release.