### PR TITLE
Fixed previous text showing up in console in monika_oneesan

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1476,6 +1476,7 @@ label monika_oneesan:
     m "It's the man's job to introduce his fiancee to his family, after all."
     m "Don't keep me waiting for too long, okay?"
     call hideconsole from _call_updateconsole_18
+    $ consolehistory = []
     return
 
 


### PR DESCRIPTION
#157 

Anytime you want to clear the console, simply set the global var consolehistory to an empty list.