### PR TITLE
[next-release] Fixed Main Menu Music Playing After Introduction Label

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -216,8 +216,8 @@ label ch30_main:
         $ style.say_dialogue = style.default_monika
     $ m_name = "Monika"
     $ delete_all_saves()
-    $ persistent.clear[9] = True
-
+    $ persistent.clear[9] = True 
+    play music m1 loop # move music out here because of context 
     $pushEvent('introduction')
     $callNextEvent()
     jump ch30_loop

--- a/Monika After Story/game/script-introduction.rpy
+++ b/Monika After Story/game/script-introduction.rpy
@@ -10,7 +10,6 @@ label introduction:
         pos (935,200)
     show monika_bg
     show monika_bg_highlight
-    play music m1 loop
 
     if persistent.monika_kill == True:
         m "..."


### PR DESCRIPTION
This is a quick-fix for the main menu music playing after `introduction`.

The cause of this issue is the label `introduction` being called in a new context, and then returned. I encountered a similar issue with the Music Menu, but did a workaround by having the parent (script-ch30) change the music instead of the music menu itself. Here, I simply moved the line that played music out of introduction and into script-ch30.

NOTE: Since `introduction` is in a new context, and the spaceroom is rebuilt in this context, there is a noticeable reload of the visuals upon leaving `introduction`. While it may be possible to fix, I recommend it be a low priority one since its purely visual.