### PR TITLE
Added suggested adjustments to music and music menu

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -117,6 +117,20 @@ init python:
         #   song - song to play
         renpy.music.play(song,channel="music",loop=True,synchro_start=True)
 
+    def mute_music():
+        #
+        # mutes the music channel
+        #
+        # ASSUMES:
+        #   songs.music_volume
+        curr_volume = songs.getVolume("music")
+        if curr_volume > 0.0:
+            songs.music_volume = songs.getVolume("music")
+            renpy.music.set_volume(0.0, channel="music")
+        else:
+            renpy.music.set_volume(songs.music_volume, channel="music")
+        
+
     def show_dialogue_box():
         if allow_dialogue:
             renpy.jump('ch30_monikatopics')
@@ -385,12 +399,14 @@ label ch30_autoload:
         $ config.allow_skipping = False
     #Add keys for new functions
     $ config.keymap["open_dialogue"] = ["t","T"]
-    $ config.keymap["change_music"] = ["m","M"]
+    $ config.keymap["change_music"] = ["noshift_m","noshift_M"]
     $ config.keymap["play_game"] = ["p","P"]
+    $ config.keymap["mute_music"] = ["shift_m","shift_M"]
     # Define what those actions call
     $ config.underlay.append(renpy.Keymap(open_dialogue=show_dialogue_box))
     $ config.underlay.append(renpy.Keymap(change_music=select_music))
     $ config.underlay.append(renpy.Keymap(play_game=pick_game))
+    $ config.underlay.append(renpy.Keymap(mute_music=mute_music))
     jump ch30_loop
 
 label ch30_loop:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -114,8 +114,11 @@ init python:
         # literally just plays a song onto the music channel
         #
         # IN:
-        #   song - song to play
-        renpy.music.play(song,channel="music",loop=True,synchro_start=True)
+        #   song - song to play. If None, the channel is stopped
+        if song is None:
+            renpy.music.stop(channel="music")
+        else:
+            renpy.music.play(song,channel="music",loop=True,synchro_start=True)
 
     def mute_music():
         #

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -128,7 +128,7 @@ init python:
         #   songs.music_volume
         curr_volume = songs.getVolume("music")
         if curr_volume > 0.0:
-            songs.music_volume = songs.getVolume("music")
+            songs.music_volume = curr_volume
             renpy.music.set_volume(0.0, channel="music")
         else:
             renpy.music.set_volume(songs.music_volume, channel="music")

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -75,6 +75,10 @@ style music_menu_outer_frame:
 screen music_menu():
     modal True
 
+    # allows the music menu to quit using hotkey
+    key "noshift_M" action Return()
+    key "noshift_m" action Return()
+
     zorder 200
 
     style_prefix "music_menu"

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -5,6 +5,15 @@
 # music inits first, so the screen can be made well
 init -1 python in songs:
 
+    # functions
+    def getVolume(channel):
+        #
+        # Gets the volume of the given audio channel
+        #
+        # IN:
+        #   channel - the audio channel to get the volume for
+        return renpy.audio.audio.get_channel(channel).context.secondary_volume
+
     # defaults
     current_track = "bgm/m1.ogg"
     selected_track = current_track
@@ -21,6 +30,12 @@ init -1 python in songs:
     music_choices.append(("Okay, Everyone! (Monika)","<loop 4.444>bgm/5_monika.ogg"))
     music_choices.append(("Surprise!","<loop 36.782>bgm/d.ogg"))
 
+
+# some post screen init is setting volume to current settings
+init 10 python in songs:
+
+    # for muting
+    music_volume = getVolume("music")
 
 # MUSIC MENU ##################################################################
 # This is the music selection menu

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -30,6 +30,9 @@ init -1 python in songs:
     music_choices.append(("Okay, Everyone! (Monika)","<loop 4.444>bgm/5_monika.ogg"))
     music_choices.append(("Surprise!","<loop 36.782>bgm/d.ogg"))
 
+    # leave this one last, so we can stopplaying stuff
+    music_choices.append(("None", None))
+
 
 # some post screen init is setting volume to current settings
 init 10 python in songs:


### PR DESCRIPTION
#222 

This pull request only includes the suggested changes for the `music menu`:
- Shift + m is a mute hotkey. Pressing it again, while muted, will unmute.
- None option added to music menu. (This will **stop** the music that is currently playing, unlike mute, which toggles the volume of the music channel. If the game is relaunched while music is stopped, the spaceroom music will play by default. I think this is fine)
- When the music menu is open, pressing m will close it appropriately.