### PR TITLE
Fix the way the chess game is querying for architecture.

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -60,6 +60,7 @@ init:
             MONIKA_THREADS = 1
 
             def __init__(self, player_color):
+                import sys
 
                 renpy.Displayable.__init__(self)
 

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -26,11 +26,11 @@ init:
 
         def is_platform_good_for_chess():
             import platform
-            if platform.machine() == 'x86_64':
+            import sys
+            if sys.maxsize > 2**32:
                 return platform.system() == 'Windows' or platform.system() == 'Linux' or platform.system() == 'Darwin'
-            elif platform.machine() == 'x86':
+            else:
                 return platform.system() == 'Windows'
-            return False
 
         def get_mouse_pos():
             vw = config.screen_width * 10000

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -103,14 +103,15 @@ init:
                 def open_stockfish(path):
                     return subprocess.Popen([renpy.loader.transfn(path)], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
+                is_64_bit = sys.maxsize > 2**32
                 if platform.system() == 'Windows':
-                    if platform.machine() == 'x86':
-                        self.stockfish = open_stockfish('mod_assets/stockfish_8_windows_x32.exe')
-                    elif platform.machine() == 'x86_64':
+                    if is_64_bit:
                         self.stockfish = open_stockfish('mod_assets/stockfish_8_windows_x64.exe')
-                elif platform.system() == 'Linux' and platform.machine() == 'x86_64':
+                    else:
+                        self.stockfish = open_stockfish('mod_assets/stockfish_8_windows_x32.exe')
+                elif platform.system() == 'Linux' and is_64_bit:
                     self.stockfish = open_stockfish('mod_assets/stockfish_8_linux_x64')
-                elif platform.system() == 'Darwin' and platform.machine() == 'x86_64':
+                elif platform.system() == 'Darwin' and is_64_bit:
                     self.stockfish = open_stockfish('mod_assets/stockfish_8_macosx_x64')
 
                 # Set Monika's parameters


### PR DESCRIPTION
Change the way the chess minigame is querying for architecture from `platform.machine()` to testing `sys.maxsize`. This can be seen as too broad since it will also match non-Intel/AMD based chipsets, but I think the chances of someone running the mod on one of those is too small to matter.