### PR TITLE
Fixed Just Monika music bug

### DIFF
--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -41,6 +41,13 @@ init 10 python in songs:
     # for muting
     music_volume = getVolume("music")
 
+# non store post inint stuff
+init 10 python:
+
+    # ensure proper current track is set
+    store.songs.current_track = persistent.current_track
+    store.songs.selected_track = store.songs.current_track
+
 # MUSIC MENU ##################################################################
 # This is the music selection menu
 ###############################################################################


### PR DESCRIPTION
If another song was loaded on startup, Just Monika would not be selectable. 

This fix properly sets `current_track` and `selected_track` in songs so Just Monika works again.