### PR TITLE
Added a function for getting currently playing song name

### DIFF
--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -12,7 +12,31 @@ init -1 python in songs:
         #
         # IN:
         #   channel - the audio channel to get the volume for
+        #
+        # RETURNS:
+        #   The volume of the given audio channel (as a double/float)
         return renpy.audio.audio.get_channel(channel).context.secondary_volume
+
+    def getPlayingMusicName():
+        #
+        # Gets the name of the currently playing song.
+        #
+        # IN:
+        #   channel - the audio channel to get the playing file 
+        #
+        # RETURNS:
+        #   The name of the currently playing song, as defined here in
+        #   music_choices, Or None if nothing is currently playing
+        #
+        # ASSUMES:
+        #   music_choices (songs store)
+        curr_filename = renpy.music.get_playing()
+        if curr_filename:
+            for name,song in music_choices:
+                if curr_filename == song:
+                    return name
+        return None
+
 
     # defaults
     current_track = "bgm/m1.ogg"


### PR DESCRIPTION
This function is available in the songs store. Make sure that `store.songs` is imported.

Here is an example: (in python context)
```
import store.songs as songs
songs.getPlayingMusicName()
```

NOTE: in script-ch30, the songs store should already be imported as `songs`

Also I added some missing documentation to the getVolume() function