### PR TITLE
Added Volume Changing Hotkeys

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -135,6 +135,20 @@ init python:
         else:
             renpy.music.set_volume(songs.music_volume, channel="music")
 
+    def inc_musicvol():
+        #
+        # increases the volume of the music channel by the value defined in
+        # songs.vol_bump
+        #
+        songs.adjustVolume()
+
+    def dec_musicvol():
+        #
+        # decreases the volume of the music channel by the value defined in
+        # songs.vol_bump
+        #
+        songs.adjustVolume(up=False)
+
     def set_keymaps():
         #
         # Sets the keymaps
@@ -147,11 +161,15 @@ init python:
         config.keymap["change_music"] = ["noshift_m","noshift_M"]
         config.keymap["play_game"] = ["p","P"]
         config.keymap["mute_music"] = ["shift_m","shift_M"]
+        config.keymap["inc_musicvol"] = ["K_PLUS","K_EQUALS","K_KP_PLUS"]
+        config.keymap["dec_musicvol"] = ["K_MINUS","K_UNDERSCORE","K_KP_MINUS"]
         # Define what those actions call
         config.underlay.append(renpy.Keymap(open_dialogue=show_dialogue_box))
         config.underlay.append(renpy.Keymap(change_music=select_music))
         config.underlay.append(renpy.Keymap(play_game=pick_game))
         config.underlay.append(renpy.Keymap(mute_music=mute_music))
+        config.underlay.append(renpy.Keymap(inc_musicvol=inc_musicvol))
+        config.underlay.append(renpy.Keymap(dec_musicvol=dec_musicvol))
 
 
     def show_dialogue_box():

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -161,8 +161,12 @@ init python:
         config.keymap["change_music"] = ["noshift_m","noshift_M"]
         config.keymap["play_game"] = ["p","P"]
         config.keymap["mute_music"] = ["shift_m","shift_M"]
-        config.keymap["inc_musicvol"] = ["K_PLUS","K_EQUALS","K_KP_PLUS"]
-        config.keymap["dec_musicvol"] = ["K_MINUS","K_UNDERSCORE","K_KP_MINUS"]
+        config.keymap["inc_musicvol"] = [
+            "shift_K_PLUS","K_EQUALS","K_KP_PLUS"
+        ]
+        config.keymap["dec_musicvol"] = [
+            "K_MINUS","shift_K_UNDERSCORE","K_KP_MINUS"
+        ]
         # Define what those actions call
         config.underlay.append(renpy.Keymap(open_dialogue=show_dialogue_box))
         config.underlay.append(renpy.Keymap(change_music=select_music))

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -4048,7 +4048,7 @@ label monika_sayhappybirthday_takecounter (take_threshold, take_counter):
    
     
         
-
+init 5 python:
     # List of keywords for the topic.
     for key in ['home memories', 'childhood']:
         monika_topics.setdefault(key,[])
@@ -4159,7 +4159,7 @@ label monika_panties:
     m 1k "I love you so much, [player]~"
     return
     
-
+init 5 python:
     #If monika were to talk about books she's read, Fahrenheit 451 would be a fitting choice for her to read
     for key in ['fahrenheit 451', 'ray bradbury']:
         monika_topics.setdefault(key,[])

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -6,6 +6,28 @@
 init -1 python in songs:
 
     # functions
+    def adjustVolume(channel="music",up=True):
+        #
+        # Adjusts the volume of the given channel by the volume bump value
+        #
+        # IN:
+        #   channel - the channel to adjust volume
+        #       (DEFAULT: music)
+        #   up - True means increase volume, False means decrease
+        #       (DEFAULT: True)
+        direct = 1
+        if not up:
+            direct = -1
+
+        # volume checks
+        new_vol = getVolume(channel)+(direct*vol_bump)
+        if new_vol < 0.0:
+            new_vol = 0.0
+        elif new_vol > 1.0:
+            new_vol = 1.0
+        
+        renpy.music.set_volume(new_vol, channel=channel)
+
     def getVolume(channel):
         #
         # Gets the volume of the given audio channel
@@ -43,6 +65,7 @@ init -1 python in songs:
     selected_track = current_track
     menu_open = False
     enabled = True
+    vol_bump = 0.1 # how much to increase volume by
 
     # SONGS:
     # if you want to add a song, add it to this list as a tuple, where:


### PR DESCRIPTION
These hotkeys change the volume of the music channel by a value defined in `store.songs.vol_bump`.

The hotkeys are:
- Increase volume: `+, =, +(Keypad plus)`
- Decrease volume: `-, _, -(Keypad minus)`

I've opted to use these hotkeys because they are seem more appropriate than some arbitrary letter.
Also the suggested letter "h" is a hotkey for hiding the screens. 

In addition, I also fixed some topics that had missing init blocks.