### PR TITLE
fix crash with dialog

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -944,7 +944,7 @@ label monika_date:
     m 1e "Gosh, it all sounds like a dream come true."
     m "When you're here, everything that we do is fun."
     m 5a "I'm so happy that I'm your girlfriend, [player]."
-    m "I'll make you a proud [boyfriend]~"
+    m "I'll make you a proud boyfriend~"
     return
 
 


### PR DESCRIPTION
A crash occurs for the text "I'll make you a proud [boyfriend]~" because boyfriend is interpreted by RenPy as a substitution, which doesn't exist.

Screenshot of crash:

![screenshot from 2017-12-06 21-07-51](https://user-images.githubusercontent.com/8469306/33697320-fe9021ba-dacb-11e7-8446-00ef72753198.png)
