### PR TITLE
Name Easter Eggs

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -128,8 +128,11 @@ init python:
         #
         # ASSUMES:
         #   songs.music_volume
+        #   persistent.playername
+
         curr_volume = songs.getVolume("music")
-        if curr_volume > 0.0:
+        # sayori cannot mute
+        if curr_volume > 0.0 and persistent.playername.lower() != "sayori":
             songs.music_volume = curr_volume
             renpy.music.set_volume(0.0, channel="music")
         else:
@@ -147,7 +150,12 @@ init python:
         # decreases the volume of the music channel by the value defined in
         # songs.vol_bump
         #
-        songs.adjustVolume(up=False)
+        # ASSUMES:
+        #   persistent.playername
+
+        # sayori cannot make the volume quieter
+        if persistent.playername.lower() != "sayori":
+            songs.adjustVolume(up=False)
 
     def set_keymaps():
         #

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -111,6 +111,25 @@ init python:
         pass
 
     #Define new functions
+
+    def enable_esc():
+        #
+        # Enables the escape key so you can go to the game menu
+        # 
+        # ASSUMES:
+        #   config.keymap
+        if "K_ESCAPE" not in config.keymap["game_menu"]:
+            config.keymap["game_menu"].append("K_ESCAPE")
+
+    def disable_esc():
+        #
+        # disables the escape key so you cant go to game menu
+        #
+        # ASSUMES:
+        #   config.keymap
+        if "K_ESCAPE" in config.keymap["game_menu"]: 
+           config.keymap["game_menu"].remove("K_ESCAPE")
+
     def play_song(song):
         #
         # literally just plays a song onto the music channel
@@ -422,19 +441,28 @@ label ch30_autoload:
         $ style.say_dialogue = style.default_monika
         $ config.allow_skipping = False
     $ quick_menu = True
-    python:
 
-        # random chance to do monika in room greeting
-        # we'll say 1 in 20 
-        import random
-        is_monika_in_room = random.randint(1,20) == 1
+    $ tempname = persistent.playername.lower()
 
+    # yuri scare incoming. No monikaroom when yuri is the name
+    if tempname == "yuri":
+        call yuri_name_scare
+        $ is_monika_in_room = False
+    else:
+        python:
+            # random chance to do monika in room greeting
+            # we'll say 1 in 20 
+            import random
+            is_monika_in_room = random.randint(1,20) == 1   
 
-        if not is_monika_in_room:
-            if persistent.current_track is not None:
-                play_song(persistent.current_track)
-            else:
-                play_song(songs.current_track) # default
+    # reset tempname
+    $ tempname = None
+
+    if not is_monika_in_room:
+        if persistent.current_track:
+            $ play_song(persistent.current_track)
+        else:
+            $ play_song(songs.current_track) # default
 
     window auto
     #If you were interrupted, push that event back on the stack

--- a/Monika After Story/game/script-easter-eggs.rpy
+++ b/Monika After Story/game/script-easter-eggs.rpy
@@ -1,0 +1,20 @@
+# script stuff that is actually easter eggs
+
+# yuri scare
+label yuri_name_scare:
+#    show yuri 3s zorder 2 at t11
+    $ HKBHideButtons()
+    $ disable_esc()
+    scene black
+    show yuri eyes zorder 2 at t11
+    play music hb
+    show layer master at heartbeat
+    show dark zorder 200
+    pause 4.0
+    hide yuri
+    hide dark
+    show layer master
+    stop music
+    $ HKBShowButtons()
+    $ enable_esc()
+    return

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -3699,6 +3699,8 @@ label monika_changename:
                             persistent.current_track = songs.sayori_track
                         else:
                             songs.initMusicChoices()
+
+                        # yuri has no adjustmeents here for now
                         
                         persistent.mcname = player
                         mcname = player

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -3691,10 +3691,19 @@ label monika_changename:
                     m 4l "That's the same name you have right now, silly!"
                     m 1b "Try again~"
                 else:
-                    $ persistent.mcname = player
-                    $ mcname = player
-                    $ persistent.playername = tempname
-                    $ player = tempname
+                    python:
+                        # easter eggs regarding names
+                        if tempname.lower() == "sayori":
+                            songs.initMusicChoices(sayori=True)
+                            play_song(songs.sayori_track)
+                            persistent.current_track = songs.sayori_track
+                        else:
+                            songs.initMusicChoices()
+                        
+                        persistent.mcname = player
+                        mcname = player
+                        persistent.playername = tempname
+                        player = tempname
                     m 1b "Ok then!"
                     m 2b "From now on, I'll call you {i}'[player]'{/i}, ehehe~"
                     $ done = True

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -59,28 +59,44 @@ init -1 python in songs:
                     return name
         return None
 
+    def initMusicChoices(sayori=False):
+        #
+        # Sets up the music choices list
+        #
+        # IN:
+        #   sayori - True if the player name is sayori, which means only
+        #       allow Surprise in the player
+
+        global music_choices
+        music_choices = list()
+        # SONGS:
+        # if you want to add a song, add it to this list as a tuple, where:
+        # [0] -> Title of song
+        # [1] -> Path to song
+        if not sayori:
+            music_choices.append(("Just Monika","bgm/m1.ogg"))
+            music_choices.append(("Your Reality","bgm/credits.ogg"))
+            music_choices.append(("I Still Love You","bgm/monika-end.ogg"))
+            music_choices.append(("Okay, Everyone! (Monika)","<loop 4.444>bgm/5_monika.ogg"))
+
+        # sayori only allows this
+        music_choices.append(("Surprise!",sayori_track))
+
+        if not sayori:
+            # leave this one last, so we can stopplaying stuff
+            music_choices.append(("None", None))
+
 
     # defaults
     current_track = "bgm/m1.ogg"
     selected_track = current_track
+    sayori_track = "<loop 36.782>bgm/d.ogg"
     menu_open = False
     enabled = True
     vol_bump = 0.1 # how much to increase volume by
 
-    # SONGS:
-    # if you want to add a song, add it to this list as a tuple, where:
-    # [0] -> Title of song
-    # [1] -> Path to song
+    # contains the song list
     music_choices = list()
-    music_choices.append(("Just Monika","bgm/m1.ogg"))
-    music_choices.append(("Your Reality","bgm/credits.ogg"))
-    music_choices.append(("I Still Love You","bgm/monika-end.ogg"))
-    music_choices.append(("Okay, Everyone! (Monika)","<loop 4.444>bgm/5_monika.ogg"))
-    music_choices.append(("Surprise!","<loop 36.782>bgm/d.ogg"))
-
-    # leave this one last, so we can stopplaying stuff
-    music_choices.append(("None", None))
-
 
 # some post screen init is setting volume to current settings
 init 10 python in songs:
@@ -92,8 +108,17 @@ init 10 python in songs:
 init 10 python:
 
     # ensure proper current track is set
-    store.songs.current_track = persistent.current_track
-    store.songs.selected_track = store.songs.current_track
+    if persistent.playername.lower() == "sayori":
+        store.songs.current_track = store.songs.sayori_track
+        store.songs.selected_track = store.songs.sayori_track
+    else:
+        store.songs.current_track = persistent.current_track
+        store.songs.selected_track = store.songs.current_track
+
+    # song choice generation
+    store.songs.initMusicChoices(
+        sayori=persistent.playername.lower() == "sayori"
+    )
 
 # MUSIC MENU ##################################################################
 # This is the music selection menu


### PR DESCRIPTION
As the name implies, here are two easter eggs regarding name choices.

Test instructions:
Sayori:
1. Run change name topic
2. Change name to "sayori" (or any case variant of sayori, like "Sayori" or "SAYORI")
3. Expect the following to occur:
  a. Music instantly changes to Surprise!
  b. Music menu no longer has options to change music or stop playing music
  c. Mute hotkey no longer works.
  d. Volume cannot be decreased (it can be increased)
4. If you quit the game and reload, the above still occurs.
5. If you change the name to something else, the music menu has options again and hotkeys are back to normal (but suprise will still be playing)

Yuri:
1. Run change name topic
2. Change name to "yuri" (or any case variant)
3. Finish change name topic
4. Close game and relaunch
5. Yuri from the closet scene plays (no actual closet, just the eyes thing and the heartbeat sound)
6. Step 5 should occur upon every game launch until name is changed to something else.

If anyone has ideas for what else the yuri easter egg should do (since its rather light), pls lmk.