### PR TITLE
Menu/Expression Bug Fix

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -4633,7 +4633,7 @@ label monika_meditation:
     m 1a "Meditating really helped to improve my mental and emotional health."
     m "I was finally able to manage my stress and feel calmer through the day."
     menu:
-        m 2b "[player], do you ever take time to meditate?"
+        m "[player], do you ever take time to meditate?"
 
         "Yes.":
             m 1k "Really? That's wonderful!"
@@ -4662,7 +4662,7 @@ init 5 python:
 label monika_otaku:
     m 1a "Hey, [player]?"
     menu:
-        m 2b "You watch anime and read manga, right?"
+        m "You watch anime and read manga, right?"
         "Yes":
             m 1a "I can't say I'm surprised, really." 
             


### PR DESCRIPTION
So it turns out that having one line of dialogue before menu choices is okay... unless they have expressions, which causes a crash. Removed expressions from the two problematic lines.