### PR TITLE
auto-update: Updater fixes. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Monika After Story/project.json
 .DS_Store
 Monika After Story/.DS_Store
 Monika After Story/characters/monika.chr
+Monika After Story/update/updates.json

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1499,7 +1499,7 @@ screen update_check(ok_action,cancel_action):
             yalign .5
             spacing 30
 
-            $latest_version = updater.UpdateVersion('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',check_interval=0)
+            $latest_version = updater.UpdateVersion('http://da605edcsie7i.cloudfront.net/updates.json',check_interval=0)
             if latest_version != None:
                 label _('An update is now avalable!'):
                     style "confirm_prompt"
@@ -1596,6 +1596,7 @@ screen updater:
                 textbutton _("Cancel") action Return()
 
 style updater_button_text is navigation_button_text
+style updater_button is confirm_button
 style updater_label is gui_label
 style updater_label_text is game_menu_label_text
 style updater_text is gui_text

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1499,7 +1499,7 @@ screen update_check(ok_action,cancel_action):
             yalign .5
             spacing 30
 
-            $latest_version = updater.UpdateVersion('http://da605edcsie7i.cloudfront.net/updates.json',check_interval=0)
+            $latest_version = updater.UpdateVersion('http://updates.monikaafterstory.com/updates.json',check_interval=0)
             if latest_version != None:
                 label _('An update is now avalable!'):
                     style "confirm_prompt"

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1571,7 +1571,7 @@ screen updater:
                 elif u.state == u.FINISHING:
                     text _("Finishing up.")
                 elif u.state == u.DONE:
-                    text _("The updates have been installed. Monika After Story will now close.")
+                    text _("The updates have been installed. Please reopen Monika After Story.")
                 elif u.state == u.DONE_NO_RESTART:
                     text _("The updates have been installed.")
                 elif u.state == u.CANCELLED:

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1499,6 +1499,7 @@ screen update_check(ok_action,cancel_action):
             yalign .5
             spacing 30
 
+            $latest_version = updater.UpdateVersion('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',check_interval=0)
             if latest_version != None:
                 label _('An update is now avalable!'):
                     style "confirm_prompt"
@@ -1538,6 +1539,7 @@ style update_check_button_text is confirm_button_text
 ##
 screen updater:
 
+    modal True
 
     style_prefix "updater"
 
@@ -1569,7 +1571,7 @@ screen updater:
                 elif u.state == u.FINISHING:
                     text _("Finishing up.")
                 elif u.state == u.DONE:
-                    text _("The updates have been installed. Monika After Story will now restart.")
+                    text _("The updates have been installed. Monika After Story will now close.")
                 elif u.state == u.DONE_NO_RESTART:
                     text _("The updates have been installed.")
                 elif u.state == u.CANCELLED:
@@ -1591,7 +1593,7 @@ screen updater:
                 textbutton _("Proceed") action u.proceed
 
             if u.can_cancel:
-                textbutton _("Cancel") action u.cancel
+                textbutton _("Cancel") action Return()
 
 style updater_button_text is navigation_button_text
 style updater_label is gui_label

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1499,7 +1499,7 @@ screen update_check(ok_action,cancel_action):
             yalign .5
             spacing 30
 
-            $latest_version = updater.UpdateVersion('http://da605edcsie7i.cloudfront.net/updates.json',check_interval=0)
+            $latest_version = updater.UpdateVersion('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',check_interval=0)
             if latest_version != None:
                 label _('An update is now avalable!'):
                     style "confirm_prompt"
@@ -1596,7 +1596,6 @@ screen updater:
                 textbutton _("Cancel") action Return()
 
 style updater_button_text is navigation_button_text
-style updater_button is confirm_button
 style updater_label is gui_label
 style updater_label_text is game_menu_label_text
 style updater_text is gui_text

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -17,9 +17,9 @@ label update_now:
     default check_wait = 21600
     if time.time()-last_updated > check_wait and updater.can_update():
         $timeout = False
-        $latest_version = updater.UpdateVersion('http://da605edcsie7i.cloudfront.net/updates.json',check_interval=0)
+        $latest_version = updater.UpdateVersion('http://updates.monikaafterstory.com/updates.json',check_interval=0)
         call screen update_check(Return(True),Return(False))
 
         if _return:
-            $updater.update('http://da605edcsie7i.cloudfront.net/updates.json',restart=True)
+            $updater.update('http://updates.monikaafterstory.com/updates.json',restart=True)
     return

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -17,9 +17,9 @@ label update_now:
     default check_wait = 21600
     if time.time()-last_updated > check_wait and updater.can_update():
         $timeout = False
-        $latest_version = updater.UpdateVersion('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',check_interval=0)
+        $latest_version = updater.UpdateVersion('http://da605edcsie7i.cloudfront.net/updates.json',check_interval=0)
         call screen update_check(Return(True),Return(False))
 
         if _return:
-            $updater.update('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',restart=True)
+            $updater.update('http://da605edcsie7i.cloudfront.net/updates.json',restart=True)
     return

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -21,5 +21,5 @@ label update_now:
         call screen update_check(Return(True),Return(False))
 
         if _return:
-            $updater.update('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json')
+            $updater.update('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',restart=True)
     return

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -17,9 +17,9 @@ label update_now:
     default check_wait = 21600
     if time.time()-last_updated > check_wait and updater.can_update():
         $timeout = False
-        $latest_version = updater.UpdateVersion('http://da605edcsie7i.cloudfront.net/updates.json',check_interval=0)
+        $latest_version = updater.UpdateVersion('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',check_interval=0)
         call screen update_check(Return(True),Return(False))
 
         if _return:
-            $updater.update('http://da605edcsie7i.cloudfront.net/updates.json',restart=True)
+            $updater.update('http://s3.us-east-2.amazonaws.com/monikaafterstory/updates.json',restart=True)
     return

--- a/Monika After Story/update/updates.json
+++ b/Monika After Story/update/updates.json
@@ -1,11 +1,2 @@
-{
-  "Mod": {
-    "sums_url": "Monika_After_Story-0.6.2-Mod.sums", 
-    "version": "094d4cdd83272783158ddef9d6ed1c157a6981b42dfea96ef0c6a2541d332121", 
-    "zsync_url": "Monika_After_Story-0.6.2-Mod.zsync", 
-    "json_url": "Monika_After_Story-0.6.2-Mod.update.json", 
-    "pretty_version": "0.6.2", 
-    "sums_size": 1848, 
-    "digest": "76cf8dad5bbf3171f0e587a9fe42578cb4f9e4d3d7614bc16bc52f5c9ffd4526"
-  }
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>updates.json</Key><RequestId>92A25029AB2D02EA</RequestId><HostId>n4oseBg+wNOS2CQQX9IOPeqcO5IqNZZ+OZxL/uRB7Z1IPvtrpHRoOsveBtvzpktOjgil/5kRNc8=</HostId></Error>

--- a/Monika After Story/update/updates.json
+++ b/Monika After Story/update/updates.json
@@ -1,2 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>updates.json</Key><RequestId>92A25029AB2D02EA</RequestId><HostId>n4oseBg+wNOS2CQQX9IOPeqcO5IqNZZ+OZxL/uRB7Z1IPvtrpHRoOsveBtvzpktOjgil/5kRNc8=</HostId></Error>
+{
+  "Mod": {
+    "sums_url": "Monika_After_Story-0.6.2-Mod.sums", 
+    "version": "094d4cdd83272783158ddef9d6ed1c157a6981b42dfea96ef0c6a2541d332121", 
+    "zsync_url": "Monika_After_Story-0.6.2-Mod.zsync", 
+    "json_url": "Monika_After_Story-0.6.2-Mod.update.json", 
+    "pretty_version": "0.6.2", 
+    "sums_size": 1848, 
+    "digest": "76cf8dad5bbf3171f0e587a9fe42578cb4f9e4d3d7614bc16bc52f5c9ffd4526"
+  }
+}


### PR DESCRIPTION
This pull request fixes a number of bugs present in the automatic updater:

1. The updater now says it will close rather than restart after updating
2. Menu buttons can no longer be clicked under the updater screen
3. Canceling the updater no longer takes you to the main menu
4. The updater no longer inappropriately times out when an update is available
5. The update server is now on cloudfront (not a bugfix, but still a necessary change)