### PR TITLE
Basic workaround for window animation issue

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -944,7 +944,7 @@ screen preferences():
                 vbox:
                     style_prefix "check"
                     label _("Room Animation")
-                    textbutton _("Disable") action Preference("video sprites", "toggle")
+                    textbutton _("Disable") action [Preference("video sprites", "toggle"), Function(renpy.call, "spaceroom",from_current=False)]
 
                 ## Additional vboxes of type "radio_pref" or "check_pref" can be
                 ## added here, to add additional creator-defined preferences.


### PR DESCRIPTION
#477 
If animations are disabled when the game is started, then enabled during game, the masks are not regenerated because `spaceroom` is not called. This workaround calls spaceroom whenever we toggle the animations. It has a side effect of canceling the `game_menu`. Can't really do anything about that so, let's just deal with it for now.
