### PR TITLE
Fix issue: lack of keys on 'monika_changename'

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -3658,7 +3658,7 @@ label monika_penname:
     return
 
 init 5 python:
-    for key in ['change name']: #Could use some mor key words
+    for key in ['change name', 'name', 'nick name']: #Could use some mor key words
         monika_topics.setdefault(key,[])
         monika_topics[key].append('monika_changename')
 


### PR DESCRIPTION
There was a deficiency for keywords in 'monika_changename' that led to confusion for players that couldn't change their name when typing 'name'. Added more keys to clear this problem. There was even a comment suggesting more keys ahaha!