### PR TITLE
Adding PGN to chess

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -74,18 +74,20 @@ init 1 python in mas_chess:
         if pgn_game.headers["Result"] != "*":
             return None
 
+        # now which one is the player?
+        if pgn_game.headers["White"] == mth:
+            the_player = "Black"
+        elif pgn_game.headers["Black"] == mth:
+            the_player = "White"
+        else: # monika must be a player
+            return None
+
         # otherwise, we can now add this as an in progress game
         # first, though we need number of turns
         # this will store the number of turns in board.fullmove_number
         board = pgn_game.board()
         for move in pgn_game.main_line():
             board.push(move)
-
-        # now which one is the player?
-        if pgn_game.headers["White"] == mth:
-            the_player = "Black"
-        else:
-            the_player = "White"
 
         return (
             CHESS_PROMPT_FORMAT.format(

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -1171,8 +1171,10 @@ label mas_chess_game_start:
     elif game_result == "1/2-1/2":
         # draw
         m 3h "A draw? How boring..."
+        persistent._mas_chess_stats["draws"] += 1
 
     elif is_monika_winner:
+        persistent._mas_chess_stats["losses"] += 1
         if is_surrender and num_turns <= 4:
             m 1e "Come on, don't give up so easily."
         else:
@@ -1185,6 +1187,7 @@ label mas_chess_game_start:
             m 1l "I really was going easy on you!"
 
     else:
+        persistent._mas_chess_stats["wins"] += 1
         #Give player XP if this is their first win
         if not persistent.ever_won['chess']:
             $persistent.ever_won['chess'] = True

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -351,7 +351,7 @@ init:
                 new_pgn = chess.pgn.Game.from_board(self.board)
 
                 if giveup:
-                    if self.playercolor == self.COLOR_WHITE:
+                    if self.player_color == self.COLOR_WHITE:
                         new_pgn.headers["Result"] = "0-1"
                     else:
                         new_pgn.headers["Result"] = "1-0"
@@ -754,8 +754,7 @@ init:
                                 not self.is_hover_button_save
                                 and self.current_turn == self.player_color
                             ):
-                            # TODO: play gui sound
-                            pass
+                            renpy.play(gui.hover_sound, channel="sound")
 
                         self.is_hover_button_save = True
                         self.is_hover_button_giveup = False
@@ -776,8 +775,7 @@ init:
                                     or self.winner
                                 )
                             ):
-                            # TODO: play gui sound
-                            pass
+                            renpy.play(gui.hover_sound, channel="sound")
 
                         self.is_hover_button_save = False
                         self.is_hover_button_giveup = True
@@ -815,7 +813,7 @@ init:
                     if self.winner:
                         
                         if self.is_hover_button_giveup:
-                            # TODO: play activate sound
+                            renpy.play(gui.activate_sound, channel="sound")
                             # user clicks Done
                             return self._quitPGN(False)
 
@@ -823,12 +821,12 @@ init:
                     elif self.current_turn == self.player_color:
                         
                         if self.is_hover_button_save:
-                            # TODO: play activate sound
+                            renpy.play(gui.activate_sound, channel="sound")
                             # user wants to save this game
                             return self._quitPGN(False)
 
                         elif self.is_hover_button_giveup:
-                            # TODO: play activate sound
+                            renpy.play(gui.activate_sound, channel="sound")
                             # user wishes to surrender (noob)
                             return self._quitPGN(True)
 
@@ -1036,6 +1034,10 @@ label demo_minigame_chess:
     # TODO: if player wants to save game, ask for name of file. Accept
     # uppercase/lowercase/numerics/dash,underscore for file names. Let user
     # know that the games are saved in <filepath>. 
+#    menu:
+#        m "Would you like to save this game?"
+#        "Yes":
+#        "No":
 
     menu:
         m "Do you want to play again?"

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -219,65 +219,7 @@ init:
                 self.move_indicator_monika = Image("mod_assets/move_indicator_monika.png")
                 self.player_move_prompt = Text(_("It's your turn, [player]!"), size=36)
                 self.num_turns = 0
-                self.surrendered = False
-
-                # hotkey button displayables
-                self.button_idle = Image("mod_assets/hkb_idle_background.png")
-                self.button_hover = Image("mod_assets/hkb_hover_background.png")
-                self.button_no = Image("mod_assets/hkb_disabled_background.png")
-
-                # hotkey button text
-                # idle style/ disabled style:
-                self.button_text_save_idle = Text(
-                    "Save",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color="#000",
-                    outlines=[]
-                )
-                self.button_text_giveup_idle = Text(
-                    "Give Up",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color="#000",
-                    outlines=[]
-                )
-                self.button_text_done_idle = Text(
-                    "Done",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color="#000",
-                    outlines=[]
-                )
-
-                # hover style
-                self.button_text_save_hover = Text(
-                    "Save",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color="#fa9",
-                    outlines=[]
-                )
-                self.button_text_giveup_hover = Text(
-                    "Give Up",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color="#fa9",
-                    outlines=[]
-                )
-                self.button_text_done_idle = Text(
-                    "Done",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color="#fa9",
-                    outlines=[]
-                )
-
-                # are we over a button?
-                self.is_hover_button_giveup = False
-                self.is_hover_button_save = False
-                self.is_disable_button_giveup = False
-                self.is_disable_button_save = False
+                self.surrendered = False           
 
                 # The sizes of some of the images.
                 self.VECTOR_PIECE_POS = {
@@ -300,6 +242,129 @@ init:
                 self.BUTTON_HEIGHT = 35
                 self.BUTTON_X_SPACING = 10
                 self.BUTTON_Y_SPACING = 10
+
+                # hotkey button displayables
+                button_idle = Image("mod_assets/hkb_idle_background.png")
+                button_hover = Image("mod_assets/hkb_hover_background.png")
+                button_no = Image("mod_assets/hkb_disabled_background.png")
+
+                # hotkey button text
+                # idle style/ disabled style:
+                button_text_save_idle = Text(
+                    "Save",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color="#000",
+                    outlines=[]
+                )
+                button_text_giveup_idle = Text(
+                    "Give Up",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color="#000",
+                    outlines=[]
+                )
+                button_text_done_idle = Text(
+                    "Done",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color="#000",
+                    outlines=[]
+                )
+
+                # hover style
+                button_text_save_hover = Text(
+                    "Save",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color="#fa9",
+                    outlines=[]
+                )
+                button_text_giveup_hover = Text(
+                    "Give Up",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color="#fa9",
+                    outlines=[]
+                )
+                button_text_done_idle = Text(
+                    "Done",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color="#fa9",
+                    outlines=[]
+                )
+
+                # calculate positions
+                self.drawn_board_x = int((1280 - self.BOARD_WIDTH) / 2)
+                self.drawn_board_y=  int((720 - self.BOARD_HEIGHT) / 2)
+                drawn_button_x = (
+                    1280 - self.drawn_board_x + self.BUTTON_X_SPACING
+                )
+                drawn_button_y_top = (
+                    720 - (
+                        (self.BUTTON_HEIGHT * 2) + 
+                        self.BUTTON_Y_SPACING +
+                        self.drawn_board_y
+                    )
+                )
+                drawn_button_y_bot = (
+                    720 - (self.BUTTON_HEIGHT + self.drawn_board_y)
+                )
+
+                # now the actual 3 buttons
+                self._button_save = MASButtonDisplayable(
+                    button_text_save_idle,
+                    button_text_save_hover,
+                    button_text_save_idle,
+                    button_idle,
+                    button_hover,
+                    button_no,
+                    drawn_button_x,
+                    drawn_button_y_top,
+                    self.BUTTON_WIDTH,
+                    self.BUTTON_HEIGHT,
+                    hover_sound=gui.hover_sound,
+                    activate_sound=gui.activate_sound
+                )
+                self._button_giveup = MASButtonDisplayable(
+                    button_text_giveup_idle,
+                    button_text_giveup_hover,
+                    button_text_giveup_idle,
+                    button_idle,
+                    button_hover,
+                    button_no,
+                    drawn_button_x,
+                    drawn_button_y_bot,
+                    self.BUTTON_WIDTH,
+                    self.BUTTON_HEIGHT,
+                    hover_sound=gui.hover_sound,
+                    activate_sound=gui.activate_sound
+                )
+                self._button_done = MASButtonDisplayable(
+                    button_text_done_idle,
+                    button_text_done_hover,
+                    button_text_done_idle,
+                    button_idle,
+                    button_hover,
+                    button_no,
+                    drawn_button_x,
+                    drawn_button_y_bot,
+                    self.BUTTON_WIDTH,
+                    self.BUTTON_HEIGHT,
+                    hover_sound=gui.activate_sound,
+                    activate_sound=gui.activate_sound
+                )
+
+                # the visible buttons list
+                self._visible_buttons = [
+                    self._button_save,
+                    self._button_giveup
+                ]
+                self._visible_buttons_winner = [
+                    self._button_save,
+                    self._button_done
+                ]
 
                 # Stockfish engine provides AI for the game.
                 # Launch the appropriate version based on the architecture and OS.
@@ -574,57 +639,24 @@ init:
                 # get the mouse pos 
                 mx, my = get_mouse_pos()
 
-                # calculate positions
-                drawn_board_x = int((width - self.BOARD_WIDTH) / 2)
-                drawn_board_y=  int((height - self.BOARD_HEIGHT) / 2)
-                self.drawn_button_x = (
-                    width - drawn_board_x + self.BUTTON_X_SPACING
-                )
-                self.drawn_button_y_top = (
-                    height - (
-                        (self.BUTTON_HEIGHT * 2) + 
-                        self.BUTTON_Y_SPACING +
-                        drawn_board_y
-                    )
-                )
-                self.drawn_button_y_bot = (
-                    height - (self.BUTTON_HEIGHT + drawn_board_y)
-                )
                 
                 # if the mouse is over a button, render that button
                 # differently
                 # winner?
+                visible_buttons = list()
                 if self.winner:
 
-                    # save disabled
-                    save_button = renpy.render(
-                        self.button_no, 1280, 720, st, at
-                    )
-                    save_button_text = renpy.render(
-                        self.button_text_save_idle, 1280, 720, st, at
-                    )               
-
-                    # giveup now says DONE
-                    # hover
-                    if self.is_hover_button_giveup:
-                        giveup_button = renpy.render(
-                            self.button_hover, 1280, 720, st, at
-                        )
-                        giveup_button_text = renpy.render(
-                            self.button_text_done_hover, 1280, 720, st, at
-                        )
-
-                    # idle
-                    else:
-                        giveup_button = renpy.render(
-                            self.button_idle, 1280, 720, st, at
-                        )
-                        giveup_button_text = renpy.render(
-                            self.button_text_done_idle, 1280, 720, st, at
-                        )                    
+                    # disable save
+                    self._button_save.disabled = True
+                   
+                    # point to the correct visible button list
+                    visible_buttons = self._visible_buttons_winner
 
                 # buttons can only be pressed on our turn
                 elif self.current_turn != self.player_color:
+
+                    self._
+
                     disabled_button = renpy.render(
                         self.button_no, 1280, 720, st, at
                     )
@@ -718,7 +750,7 @@ init:
                 sbt_w, sbt_h = save_button_text.get_size()
 
                 # Draw the board.
-                r.blit(board, (drawn_board_x, drawn_board_y))
+                r.blit(board, (self.drawn_board_x, self.drawn_board_y))
                 indicator_position = (int((width - self.INDICATOR_WIDTH) / 2 + self.BOARD_WIDTH / 2 + 50),
                                       int((height - self.INDICATOR_HEIGHT) / 2))
 
@@ -876,51 +908,8 @@ init:
                 if ev.type in self.MOUSE_EVENTS:
                     # are we in mouse button things
 
-                    # checking save button first
-                    if (
-                            self._inButton(
-                                x, 
-                                y, 
-                                self.drawn_button_x, 
-                                self.drawn_button_y_top
-                            )
-                        ):
-                        
-                        if (
-                                not self.is_hover_button_save
-                                and self.current_turn == self.player_color
-                                and self.board.fullmove_number > 4
-                            ):
-                            renpy.play(gui.hover_sound, channel="sound")
-                            self.is_hover_button_save = True
+                    
 
-                        self.is_hover_button_giveup = False
-
-                    # checking the give up button
-                    elif (
-                            self._inButton(
-                                x,
-                                y,
-                                self.drawn_button_x,
-                                self.drawn_button_y_bot
-                            )
-                        ):
-                        if (
-                                not self.is_hover_button_giveup
-                                and (
-                                    self.current_turn == self.player_color 
-                                    or self.winner
-                                )
-                            ):
-                            renpy.play(gui.hover_sound, channel="sound")
-                            self.is_hover_button_giveup = True
-
-                        self.is_hover_button_save = False
-
-                    # otherwise no buttons
-                    else:
-                        self.is_hover_button_save = False
-                        self.is_hover_button_giveup = False
 
                 def get_piece_pos():
                     mx, my = get_mouse_pos()

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -1198,7 +1198,8 @@ label mas_chess_end:
         m 1a "It's okay if you find yourself struggling at times."
         m 1j "Remember, the important thing is to be able to learn from your mistakes."
     elif game_result == "*":
-        m 1a "TODO: okay lets play again soon"
+        # TODO: this really should be better
+        m 1a "Okay, [player], let's continue this game soon."
     else:
         m 2b "It's amazing how much more I have to learn even now."
         m 2a "I really don't mind losing as long as I can learn something."

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -1116,9 +1116,13 @@ label demo_minigame_chess:
             else:
                 $ game_s_dialog = "some games"
 
+            python:
+                # sort the games
+                pgn_games.sort()
+                pgn_games.reverse()
+
             # need to add the play new game option
             $ pgn_games.append(mas_chess.CHESS_MENU_NEW_GAME_ITEM)
-
             
             m 1a "We still have [game_s_dialog] in progress."
             show monika at t21

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -485,10 +485,10 @@ init:
                 # If it's Monika's turn, send her the board positions so that she can start analyzing.
                 if player_color != self.current_turn:
                     self.start_monika_analysis()
-                    self._button_save.disabled = True
-                    self._button_giveup.disabled = True
+                    self._button_save.disable()
+                    self._button_giveup.disable()
                 elif self.board.fullmove_number <= 4:
-                    self._button_save.disabled = True
+                    self._button_save.disable()
 
             def start_monika_analysis(self):
                 self.stockfish.stdin.write("position fen %s" % (self.board.fen()) + '\n')
@@ -628,11 +628,11 @@ init:
                         # we assume buttons were disabled prior to here
                         # (not Done though)
                         if not self.winner:
-                            self._button_giveup.disabled = False
+                            self._button_giveup.enable()
 
                             # enable button only after 4th move
                             if self.num_turns > 4:
-                                self._button_save.disabled = False
+                                self._button_save.enable()
 
                 # The Render object we'll be drawing into.
                 r = renpy.Render(width, height)
@@ -911,8 +911,8 @@ init:
                                 self.start_monika_analysis()
 
                             # disable the buttons when your turn is done
-                            self._button_save.disabled = True
-                            self._button_giveup.disabled = True
+                            self._button_save.disable()
+                            self._button_giveup.disable()
 
                     self.selected_piece = None
                     # NOTE: DEBUG

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -156,6 +156,8 @@ init:
                 # are we over a button?
                 self.is_hover_button_giveup = False
                 self.is_hover_button_save = False
+                self.is_disable_button_giveup = False
+                self.is_disable_button_save = False
 
                 # The sizes of some of the images.
                 self.VECTOR_PIECE_POS = {
@@ -468,8 +470,7 @@ init:
                 self.drawn_button_y_bot = (
                     height - (self.BUTTON_HEIGHT + drawn_board_y)
                 )
-
-                # prepare the buttons (depends on mouse)
+                
                 # if the mouse is over a button, render that button
                 # differently
                 # winner?
@@ -734,7 +735,7 @@ init:
 
             # Handles events.
             def event(self, ev, x, y, st):
-
+ 
                 # check muouse position
                 if ev.type in self.MOUSE_EVENTS:
                     # are we in mouse button things
@@ -748,6 +749,14 @@ init:
                                 self.drawn_button_y_top
                             )
                         ):
+                        
+                        if (
+                                not self.is_hover_button_save
+                                and self.current_turn == self.player_color
+                            ):
+                            # TODO: play gui sound
+                            pass
+
                         self.is_hover_button_save = True
                         self.is_hover_button_giveup = False
 
@@ -760,6 +769,16 @@ init:
                                 self.drawn_button_y_bot
                             )
                         ):
+                        if (
+                                not self.is_hover_button_giveup
+                                and (
+                                    self.current_turn == self.player_color 
+                                    or self.winner
+                                )
+                            ):
+                            # TODO: play gui sound
+                            pass
+
                         self.is_hover_button_save = False
                         self.is_hover_button_giveup = True
 
@@ -796,6 +815,7 @@ init:
                     if self.winner:
                         
                         if self.is_hover_button_giveup:
+                            # TODO: play activate sound
                             # user clicks Done
                             return self._quitPGN(False)
 
@@ -803,10 +823,12 @@ init:
                     elif self.current_turn == self.player_color:
                         
                         if self.is_hover_button_save:
+                            # TODO: play activate sound
                             # user wants to save this game
                             return self._quitPGN(False)
 
                         elif self.is_hover_button_giveup:
+                            # TODO: play activate sound
                             # user wishes to surrender (noob)
                             return self._quitPGN(True)
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -550,6 +550,15 @@ python early:
             return_value - Value returned when button is activated
             disabled - True means to disable this button, False not
             hovered - True if we are being hovered, False if not
+            _button_click - integer value to match a mouse click:
+                1 - left (Default)
+                2 - middle
+                3 - right
+                4 - scroll up
+                5 - scroll down
+            _button_down - pygame mouse button event type to activate button
+                MOUSEBUTTONDOWN (Default)
+                MOUSEBUTTONUP
         """
         import pygame
 
@@ -630,6 +639,8 @@ python early:
             self.return_value = return_value
             self.disabled = False
             self.hovered = False
+            self._button_click = 1
+            self._button_down = pygame.MOUSEBUTTONDOWN
 
             # the states of a button
             self._button_states = {
@@ -733,7 +744,10 @@ python early:
                         if self.hover_sound:
                             self._playHoverSound()
 
-                elif ev.type == pygame.MOUSEBUTTONDOWN:
+                elif (
+                        ev.type == self._button_down 
+                        and ev.button == self._button_click
+                    ):
                     if self.hovered:
                         if self.activate_sound:
                             self._playActivateSound()

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -681,16 +681,6 @@ python early:
                 renpy.play(self.hover_sound, channel="sound")
 
 
-        def enable(self):
-            """
-            Enables this button. This changes the internal state, so its
-            preferable to use this over setting the disabled property 
-            directly
-            """
-            self.disabled = False
-            self._state = self._STATE_IDLE
-
-
         def disable(self):
             """
             Disables this button. This changes the internal state, so its
@@ -699,6 +689,16 @@ python early:
             """
             self.disabled = True
             self._state = self._STATE_DISABLED
+
+
+        def enable(self):
+            """
+            Enables this button. This changes the internal state, so its
+            preferable to use this over setting the disabled property 
+            directly
+            """
+            self.disabled = False
+            self._state = self._STATE_IDLE
 
 
         def getSize(self):
@@ -711,6 +711,37 @@ python early:
                     [1]: height
             """
             return (self.width, self.height)
+
+        
+        def ground(self):
+            """
+            Grounds (unhovers) this button. This changes the internal state,
+            so its preferable to use this over setting the hovered property
+            directly
+
+            NOTE: If this button is disabled (and not enable_when_disabled),
+            this will do NOTHING
+            """
+            if not self.disabled or self.enable_when_disabled:
+                self.hovered = False
+
+                if self.disabled:
+                    self._state = self._STATE_DISABLED
+                else:
+                    self._state = self._STATE_IDLE
+
+
+        def hover(self):
+            """
+            Hovers this button. This changes the internal state, so its
+            preferable to use this over setting the hovered property directly
+
+            NOTE: IF this button is disabled (and not enable_when_disabled),
+            this will do NOTHING
+            """
+            if not self.disabled or self.enable_when_disabled:
+                self.hovered = True
+                self._state = self._STATE_HOVER
 
 
         def render(self, width, height, st, at):

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -681,6 +681,26 @@ python early:
                 renpy.play(self.hover_sound, channel="sound")
 
 
+        def enable(self):
+            """
+            Enables this button. This changes the internal state, so its
+            preferable to use this over setting the disabled property 
+            directly
+            """
+            self.disabled = False
+            self._state = self._STATE_IDLE
+
+
+        def disable(self):
+            """
+            Disables this button. This changes the internal state, so its
+            preferable to use this over setting the disabled property
+            directly
+            """
+            self.disabled = True
+            self._state = self._STATE_DISABLED
+
+
         def getSize(self):
             """
             Returns the size of this button
@@ -695,10 +715,6 @@ python early:
 
         def render(self, width, height, st, at):
 
-            # disable if we need to
-            if self.disabled:
-                self._state = self._STATE_DISABLED
-           
             # pull out the current button back and text and render them
             render_text, render_back = self._button_states[self._state]
             render_text = renpy.render(render_text, width, height, st, at)
@@ -725,7 +741,7 @@ python early:
           
             # only check if we arent disabled (or are allowed to work while
             #   disabled)
-            if not self.disabled or self.enable_when_disabled:
+            if self._state != self._STATE_DISABLED or self.enable_when_disabled:
 
                 # we onyl care about mouse events here
                 if ev.type == pygame.MOUSEMOTION:
@@ -752,9 +768,6 @@ python early:
                         if self.activate_sound:
                             self._playActivateSound()
                         return self.return_value
-
-            else: # since we are disabled
-                self._state = self._STATE_DISABLED
 
             # otherwise continue on
             return None

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1825,7 +1825,7 @@ define xp.IDLE_PER_MINUTE = 1
 define xp.IDLE_XP_MAX = 120
 define xp.NEW_EVENT = 15
 define is_monika_in_room = False # since everyone gets this error apparently
-define monika_twitter_handle = "lilmonix3"
+define mas_monika_twitter_handle = "lilmonix3"
 init python:
     startup_check = False
     try:

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1825,6 +1825,7 @@ define xp.IDLE_PER_MINUTE = 1
 define xp.IDLE_XP_MAX = 120
 define xp.NEW_EVENT = 15
 define is_monika_in_room = False # since everyone gets this error apparently
+define monika_twitter_handle = "lilmonix3"
 init python:
     startup_check = False
     try:

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1822,6 +1822,12 @@ style scrollable_menu_special_button is scrollable_menu_button
 style scrollable_menu_special_button_text is scrollable_menu_button_text:
     bold True
 
+style scrollable_menu_crazy_button is scrollable_menu_button
+
+style scrollable_menu_crazy_button_text is scrollable_menu_button_text:
+    italic True
+    bold True
+
 # two pane stuff
 style twopane_scrollable_menu_vbox:
     xalign 0.5
@@ -1940,3 +1946,68 @@ screen scrollable_menu(items, display_area, scroll_align):
                     null height 20
 
                     textbutton _("That's enough for now.") action Return(False)
+
+# more generali scrollable menu. This one takes the following params:
+# IN:
+#   items - list of items to display in the menu. Each item must be a tuple of
+#       the following format:
+#           [0]: prompt button
+#           [1]: prompt return object
+#           [2]: True if we want the button italics, False if not
+#           [3]: True if we want the button bold, False if not
+#   display_area - defines the display area of the menu. Tuple of the following
+#       format:
+#           [0]: x coordinate of menu
+#           [1]: y coordinate of menu
+#           [2]: width of menu
+#           [3]: height of menu
+#   scroll_align - alignment of vertical scrollbar
+#   final_item - represents the final (usually quit item) of the menu
+#       tuple of the following format:
+#           [0]: text of the button
+#           [1]: return value of the button
+#           [2]: True if we want the button italics, False if not
+#           [3]: True if we want the button bold, False if not
+#           [4]: integer spacing between this button and the regular buttons
+#               NOTE: must be >= 0
+#       (Default: None)
+screen mas_gen_scrollable_menu(items, display_area, scroll_align, final_item=None):
+        style_prefix "scrollable_menu"
+
+        fixed:
+            area display_area
+
+            bar adjustment prev_adj style "vscrollbar" xalign scroll_align
+
+            viewport:
+                yadjustment prev_adj
+                mousewheel True
+
+                vbox:
+#                    xpos x
+#                    ypos y
+
+                    for item_prompt,item_value,is_italic,is_bold in items:
+                        textbutton item_prompt:
+                            if is_italic and is_bold:
+                                style "scrollable_menu_crazy_button"
+                            elif is_italic:
+                                style "scrollable_menu_new_button"
+                            elif is_bold:
+                                style "scrollable_menu_special_button"
+                            action Return(item_value)
+
+                    if final_item:
+                        if final_item[4] > 0:
+                            null height final_item[4]
+
+                        textbutton _(final_item[0]):
+                            if final_item[2] and final_item[3]:
+                                style "scrollable_menu_crazy_button"
+                            elif final_item[2]:
+                                style "scrollable_menu_new_button"
+                            elif final_item[3]:
+                                style "scrollable_menu_special_button"
+                            action Return(final_item[1])
+
+

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -145,6 +145,10 @@ label monika_changename:
                     m 2h "..."
                     m 4l "That's the same name you have right now, silly!"
                     m 1b "Try again~"
+                elif lowername == monika_twitter_handle:
+                    m 2h "..."
+                    # TODO: make this neater
+                    m "what the fuck can you just not pick my twitter handle"
                 elif len(lowername) >= 10:
                     m 2q "[player]..."
                     m 2l "That name's a bit too long."

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -77,6 +77,9 @@ label preferredname:
                     m 1q "..."
                     m 1l "That's the same name you have right now, silly!"
                     m 1e "Try again~"
+                elif lowername == monika_twitter_handle:
+                    m 2h "..."
+                    # TODO: actaully have dialog here
                 elif len(lowername) >= 10:
                     m 2q "[player]..."
                     m 2l "That name's a bit too long."
@@ -147,8 +150,7 @@ label monika_changename:
                     m 1b "Try again~"
                 elif lowername == monika_twitter_handle:
                     m 2h "..."
-                    # TODO: make this neater
-                    m "what the fuck can you just not pick my twitter handle"
+                    # TODO: actaully have dialog here
                 elif len(lowername) >= 10:
                     m 2q "[player]..."
                     m 2l "That name's a bit too long."


### PR DESCRIPTION
This does bits of #810 . 

### Update:
This now uses the `MASButtonDisplayable` class I've created.

### NOTE:
This is in `content` because it was supposed to be part of a chess enhancement. I don't think this should be in `next-release` since it doesn't really break anything outside of `chess`.

### Chess:

Main focus of this was to add PGN to chess so players can see their games with Monika, but seeing at how `chess.pgn` is already built into the library we were using, I decided going the full mile and implementing a direct save/load chess game system.

Key points:
1. The chess board now has two buttons: `Save` and `Give Up`. Give up is replacing the `double click your king to surrender.` It also has a nice dialog box that shows up. `Save` allows you to save your game. **(You can only save your game after 4 black turns)**
2. Saving is as simple as giving the game a name (asked for using an input box). The saved games are stored in `chess_games/<name>.pgn`. Games have a max name of 20 characters.
3. If an ongoing game was loaded, asking to save is still shown, but game is saved to same name/file.
4. Upon launching chess, Monika now checks for saved games that: she was a player in, are ongoing (no result). She prompts the user for picking a saved game or playing a new one.
5. The Loaded games are shown in a scrollable pane with the following descriptors: `<date> | <name> | <turn count> | <player color>`. Entries are sorted by Date (kind of)
6. Games are saved in PGN notation.

Picture of load menu: (which could use some work)
![chessgame](https://user-images.githubusercontent.com/3499462/35663943-748ea036-06e5-11e8-9348-0b13142c642f.png)

Additional Adjustments:
In order to make this new chess system work, some other offhand adjustments were made:
1. New definition `mas_monika_twitter_handle`. Her twitter handle is how we signify Monika's side in PGN notation. 
2. Change name flow refuses Monika's twitter handle. This is to ensure we dont have stupid crap when loading a chess game.
3. New generic scrollable pane. This one is way nicer than the existing ones, allowing us to modify styles of buttons based on some boolean values in an item tuple instead of checking for label existence. Check `screens.rpy` for full documentation.
4. This is unrelated, but I've added stat tracking of wins/losses/draws. We can use this in the future.

Dialogue: 
- [ ] In `script-story-events`, lines 149-151: dialogue for when user tries to change name to twitter handle. (I didnt put any effort here, sorry)
- [ ] In `chess`, lines 1010-1012: dialgoue saying we still have games in progress
- [ ] In `chess`, line 1021: User does not wish to play chess no more (they clicked nevermind)
- [ ] In `chess`, lines 1164-1165: Monika "waits" and saves your game, also tells you where to find it (relative path, using absolute path was just stupid long)
- [ ] In `chess`, lines 1170-1171: Monika explains PGN notation. This is only shown once.
- [ ] In `chess`, lines 1174-1178: Monika continues explaining PGN, but this is only if your first save was a game that you didn't finish. Just a little quip about how the player shouldn't cheat by editing the PGN file.
- [ ] In `chess`, line 1183: user clicks "No" to saving question, not sure if dialogue should be here
- [ ] In `chess`, line 1201: User saved an ongoing game, so Monika should say something like "play again soon"

API:
1. All (I think all) of the new labels/stores/persistents/screens/vars are using the new prefixing schema we decided on in discord (it's partially on the Style guide as well). 
2. The existing chess labels/data structures and whatever are still non-compliant. Probably need to do that in the future.

Notes:
- Somehow this evolved from adding a silent PGN writer to redoing parts of chess with nice buttons. Crazy how things happen. 
- ~~Adding buttons is quite a doozy but is possible in custom Displayables.~~ Subverted by the `MASButtonDisplayable` class
- Screens can be called from custom Displayables by `calling_in_new_context` labels that call those screens. We could probably use that for many things.
- Yes, I did say PGN notation. I'm probably retarted.