### PR TITLE
Configurable Piano Keys

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -550,6 +550,15 @@ python early:
             return_value - Value returned when button is activated
             disabled - True means to disable this button, False not
             hovered - True if we are being hovered, False if not
+            _button_click - integer value to match a mouse click:
+                1 - left (Default)
+                2 - middle
+                3 - right
+                4 - scroll up
+                5 - scroll down
+            _button_down - pygame mouse button event type to activate button
+                MOUSEBUTTONDOWN (Default)
+                MOUSEBUTTONUP
         """
         import pygame
 
@@ -630,6 +639,8 @@ python early:
             self.return_value = return_value
             self.disabled = False
             self.hovered = False
+            self._button_click = 1
+            self._button_down = pygame.MOUSEBUTTONDOWN
 
             # the states of a button
             self._button_states = {
@@ -733,7 +744,10 @@ python early:
                         if self.hover_sound:
                             self._playHoverSound()
 
-                elif ev.type == pygame.MOUSEBUTTONDOWN:
+                elif (
+                        ev.type == self._button_down 
+                        and ev.button == self._button_click
+                    ):
                     if self.hovered:
                         if self.activate_sound:
                             self._playActivateSound()

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -526,6 +526,132 @@ python early:
 
             return events
 
+init -1 python:
+    # this should be in the EARLY block
+    class MASButtonDisplayable(Displayable):
+        """
+        Special button type that represents a usable button for custom 
+        displayables.
+
+        PROPERTIES:
+            width - width of this button
+            height - height of this button
+            hover_sound - sound played when being hovered (this is played only
+                once per hover. IF None, no sound is played)
+            activate_sound - sound played when activated (this is played only
+                once per activation. If None, no sound is played)
+            enable_when_disabled - True means that the button is active even
+                if shown disabled. False if otherwise
+            return_value - Value returned when button is activated
+            disabled - True means to disable this button, False not
+            hovered - True if we are being hovered, False if not
+        """
+        import pygame
+
+        # states of the button
+        _STATE_IDLE = 0
+        _STATE_HOVER = 1
+        _STATE_DISABLED = 2
+
+        # indexes for button parts
+        _INDEX_TEXT = 0
+        _INDEX_BUTTON = 1
+
+        def __init__(self,
+                idle_text,
+                hover_text,
+                disable_text,
+                idle_back,
+                hover_back,
+                disable_back,
+                width,
+                height,
+                hover_sound=None,
+                activate_sound=None,
+                enable_when_disabled=False,
+                return_value=True
+            ):
+            """
+            Constructor for the custom displayable
+
+            IN:
+                idle_text - Text object to show when button is idle
+                hover_text - Text object to show when button is being hovered
+                disable_text - Text object to show when button is disabled
+                idle_back - Image object for background when button is idle
+                hover_back - Image object for background when button is being
+                    hovered
+                disable_back - Image object for background when button is
+                    disabled
+                with - with of this button
+                height - height of this button
+                hover_sound - sound to play when hovering. If None, no sound
+                    is played
+                    (Default: None)
+                activate_sound - sound to play when activated. If None, no
+                    sound is played
+                    (Default: None)
+                enable_when_disabled - True will enable the button even if
+                    it is visibly disabled. FAlse will not
+                    (Default: False)
+                return_value - Value to return when the button is activated
+                    (Default: True)
+            """
+
+            # setup
+#            self.idle_text = idle_text
+#            self.hover_text = hover_text
+#            self.disable_text = disable_text
+#            self.idle_back = idle_back
+#            self.hover_back = hover_back
+#            self.disable_back = disable_back
+            self.width = width
+            self.height = height
+            self.hover_sound = hover_sound
+            self.activate_sound = activate_sound
+            self.enable_when_disabled = enable_when_disable
+            self.return_value = return_value
+            self.disabled = False
+            self.hovered = False
+
+            # the states of a button
+            self._button_states = {
+                self._STATE_IDLE: (idle_text, idle_back),
+                self._STATE_HOVER: (hover_text, hover_back),
+                self._STATE_DISABLED: (disable_text, disable_back)
+            }
+
+            # current state
+            self._state = self._STATE_IDLE
+
+        def render(self, width, height, st, at):
+           
+            # pull out the current button back and text and render them
+            render_text, render_back = self._button_states[self._state]
+            render_text = renpy.render(render_text, width, height, st, at)
+            render_back = renpy.render(render_back, width, height, st, at)
+
+            # what is the text's with and height
+            rt_w, rt_h = render_text.get_size()
+
+            # build our renderer
+            r = renpy.Render(self.width, self.height)
+
+            # blit our textures
+            r.blit(render_back, (0, 0))
+            r.blit(
+                render_text,
+                (int((self.width - rt_w) / 2), int((self.height - rt_h) / 2))
+            )
+
+            # return rendere
+            return r
+
+#        def event(self, ev, x, y, st):
+            
+            # we onyl care about mouse events here
+#            if ev.type == pygame.MOUSEMOTION:
+                
 
 init -1 python:
     config.keymap['game_menu'].remove('mouseup_3')
@@ -595,7 +721,6 @@ init -1 python:
         except:
             appIds = None
         return appIds
-
 
 # Music
 define audio.t1 = "<loop 22.073>bgm/1.ogg"  #Main theme (title)

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -681,16 +681,6 @@ python early:
                 renpy.play(self.hover_sound, channel="sound")
 
 
-        def enable(self):
-            """
-            Enables this button. This changes the internal state, so its
-            preferable to use this over setting the disabled property 
-            directly
-            """
-            self.disabled = False
-            self._state = self._STATE_IDLE
-
-
         def disable(self):
             """
             Disables this button. This changes the internal state, so its
@@ -699,6 +689,16 @@ python early:
             """
             self.disabled = True
             self._state = self._STATE_DISABLED
+
+
+        def enable(self):
+            """
+            Enables this button. This changes the internal state, so its
+            preferable to use this over setting the disabled property 
+            directly
+            """
+            self.disabled = False
+            self._state = self._STATE_IDLE
 
 
         def getSize(self):
@@ -711,6 +711,37 @@ python early:
                     [1]: height
             """
             return (self.width, self.height)
+
+        
+        def ground(self):
+            """
+            Grounds (unhovers) this button. This changes the internal state,
+            so its preferable to use this over setting the hovered property
+            directly
+
+            NOTE: If this button is disabled (and not enable_when_disabled),
+            this will do NOTHING
+            """
+            if not self.disabled or self.enable_when_disabled:
+                self.hovered = False
+
+                if self.disabled:
+                    self._state = self._STATE_DISABLED
+                else:
+                    self._state = self._STATE_IDLE
+
+
+        def hover(self):
+            """
+            Hovers this button. This changes the internal state, so its
+            preferable to use this over setting the hovered property directly
+
+            NOTE: IF this button is disabled (and not enable_when_disabled),
+            this will do NOTHING
+            """
+            if not self.disabled or self.enable_when_disabled:
+                self.hovered = True
+                self._state = self._STATE_HOVER
 
 
         def render(self, width, height, st, at):

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -681,6 +681,26 @@ python early:
                 renpy.play(self.hover_sound, channel="sound")
 
 
+        def enable(self):
+            """
+            Enables this button. This changes the internal state, so its
+            preferable to use this over setting the disabled property 
+            directly
+            """
+            self.disabled = False
+            self._state = self._STATE_IDLE
+
+
+        def disable(self):
+            """
+            Disables this button. This changes the internal state, so its
+            preferable to use this over setting the disabled property
+            directly
+            """
+            self.disabled = True
+            self._state = self._STATE_DISABLED
+
+
         def getSize(self):
             """
             Returns the size of this button
@@ -695,10 +715,6 @@ python early:
 
         def render(self, width, height, st, at):
 
-            # disable if we need to
-            if self.disabled:
-                self._state = self._STATE_DISABLED
-           
             # pull out the current button back and text and render them
             render_text, render_back = self._button_states[self._state]
             render_text = renpy.render(render_text, width, height, st, at)
@@ -725,7 +741,7 @@ python early:
           
             # only check if we arent disabled (or are allowed to work while
             #   disabled)
-            if not self.disabled or self.enable_when_disabled:
+            if self._state != self._STATE_DISABLED or self.enable_when_disabled:
 
                 # we onyl care about mouse events here
                 if ev.type == pygame.MOUSEMOTION:
@@ -752,9 +768,6 @@ python early:
                         if self.activate_sound:
                             self._playActivateSound()
                         return self.return_value
-
-            else: # since we are disabled
-                self._state = self._STATE_DISABLED
 
             # otherwise continue on
             return None

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -719,9 +719,12 @@ python early:
                 # we onyl care about mouse events here
                 if ev.type == pygame.MOUSEMOTION:
                     is_over_me = self._isOverMe(x, y)
-                    if self.hovered and not is_over_me:
-                        self.hovered = False
-                        self._state = self._STATE_IDLE
+                    if self.hovered:
+                        if not is_over_me:
+                            self.hovered = False
+                            self._state = self._STATE_IDLE
+
+                        # else remain in hover mode
 
                     elif is_over_me:
                         self.hovered = True
@@ -732,6 +735,8 @@ python early:
 
                 elif ev.type == pygame.MOUSEBUTTONDOWN:
                     if self.hovered:
+                        if self.activate_sound:
+                            self._playActivateSound()
                         return self.return_value
 
             else: # since we are disabled

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -370,9 +370,9 @@ label pick_a_game:
                     $ grant_xp(xp.NEW_GAME)
                 call game_hangman from _call_game_hangman
             "Piano" if persistent.game_unlocks['piano']:
-                if not renpy.seen_label("zz_play_piano"):
+                if not renpy.seen_label("mas_piano_start"):
                     $ grant_xp(xp.NEW_GAME)
-                call zz_play_piano from _call_play_piano
+                call mas_piano_start from _call_play_piano
             "Nevermind":
                 m "Alright. Maybe later?"
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -174,6 +174,9 @@ init 10 python:
 #
 # NOTE: the labels here mean we are updating TO this version
 
+# TODO: piano label changed from 0.7.0 to 0.7.1:
+#   zz_play_piano -> mas_piano_start
+
 # all generic (only updateTopicID calls) go here
 label vgenericupdate(version="v0_2_2"):
 label v0_6_1(version=version): # 0.6.1

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -1734,6 +1734,8 @@ init 1001 python:
             }
 
             # overlay setup
+            blank_text = Text("")
+            blank_img = Solid("#fff0")
             left = Image(self.ZZPK_W_OVL_LEFT)
             right = Image(self.ZZPK_W_OVL_RIGHT)
             center = Image(self.ZZPK_W_OVL_CENTER)
@@ -1790,7 +1792,6 @@ init 1001 python:
                     x,
                     self.ZZPK_IMG_KEYS_Y
                 )
-
 
             # list containing lists of matches.
             # NOTE: highly recommend not adding too many detections

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -2426,6 +2426,7 @@ init 1001 python:
             # the default so we can keep going
             raise renpy.IgnoreEvent()
 
+
 # custom piano displayable class for setting up key configurations
     class PianoSetupDisplayable(PianoDisplayable):
         """
@@ -2446,6 +2447,10 @@ init 1001 python:
         # Clickable buttons: CANCEL / RESET
         STATE_CHANGE = 1
 
+        # button names
+        BUTTON_DONE = 0
+        BUTTON_CANCEL = 1
+        BUTTON_RESET = 2
 
         def __init__(self):
             """
@@ -2461,6 +2466,13 @@ init 1001 python:
             self.button_idle = Image("mod_assets/hkb_idle_background")
             self.button_hover = Image("mod_assets/hkb_hover_background")
             self.button_disabled = Image("mod_assets/hkb_disabled_background")
+
+            # dict of button states
+            self.button_states = {
+                
+
+        def _decideButton(self, 
+
 
         def _setKeymap(self, keydex, new, old=None):
             """

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -22,7 +22,7 @@ define xp.ZZPK_FULLCOMBO = 40
 define xp.ZZPK_PRACTICE = 15
 
 # label that calls this creen
-label zz_play_piano:
+label mas_piano_start:
 
     # initial setup
     $ import store.mas_piano_keys as mas_piano_keys
@@ -32,14 +32,14 @@ label zz_play_piano:
     # Intro to piano dialogue here
     m 1j "You want to play the piano?"
 
-label zz_play_piano_loopstart:
+label mas_piano_loopstart:
 
     # get song list
     $ song_list = mas_piano_keys.getSongChoices()
     $ pnml = None
     $ play_mode = PianoDisplayable.MODE_FREE
 
-label zz_play_piano_songchoice:
+label mas_piano_songchoice:
 
     if len(song_list) > 1:
         show monika 1a
@@ -65,22 +65,22 @@ label zz_play_piano_songchoice:
                     # regardless, set mode
                     $ play_mode = PianoDisplayable.MODE_SONG
 
-                    jump zz_play_piano_setupstart
+                    jump mas_piano_setupstart
 
                 # nvermind selected
                 else:
-                    jump zz_play_piano_songchoice
+                    jump mas_piano_songchoice
 
             "On my own":
                 pass
 
             "Nevermind":
-                jump zz_play_piano_loopend
+                jump mas_piano_loopend
 
     # otherwise, we default to freestyle mode
     m 1a "Then play for me, [player]~"
 
-label zz_play_piano_setupstart:
+label mas_piano_setupstart:
 
     show monika 1a at t22
 
@@ -116,31 +116,27 @@ label zz_play_piano_setupstart:
     call expression post_piano from _zzpk_ppel
 
     # No-hits dont get to try again
-    if post_piano != "zz_piano_none":
+    if post_piano != "mas_piano_result_none":
         show monika 1a
         menu:
             m "Would you like to play again?"
             "Yes":
-                jump zz_play_piano_loopstart
+                jump mas_piano_loopstart
             "No":
                 pass
 
-label zz_play_piano_loopend:
-    return
-
-
-label mas_piano_configure:
+label mas_piano_loopend:
     return
 
 ### labels for piano states ===================================================
 
 # default. post game, freestyle mode
-label zz_piano_default:
+label mas_piano_result_default:
     m 1a "All done, [player]?"
     return
 
 # Shown if player does not hit any notes
-label zz_piano_none:
+label mas_piano_result_none:
     m 1m "Uhhh [player]..."
     m 1l "I thought you wanted to play the piano?"
     m 1e "I really enjoy hearing you play."
@@ -150,7 +146,7 @@ label zz_piano_none:
 ### YOUR REALITY
 
 # shown if player completes the song but does not FC
-label zz_piano_yr_win:
+label mas_piano_yr_win:
     m 1m "That was nice, [player]."
     m "But..."
     m 1n "You could do better with some more practice..."
@@ -158,21 +154,21 @@ label zz_piano_yr_win:
     return
 
 # shown if player FCs
-label zz_piano_yr_fc:
+label mas_piano_yr_fc:
     m 1b "That was wonderful, [player]!"
     m 1j "I didn't know you can play the piano so well."
     m 1a "Maybe we should play together sometime!"
     return
 
 # shown if player did not complete song and had more fails than passes
-label zz_piano_yr_fail:
+label mas_piano_yr_fail:
     m 1o "..."
     m 1e "That's okay, [player]."
     m 1j "At least you tried your best."
     return
 
 # shown if player did not complete song but had more passes than fails
-label zz_piano_yr_prac:
+label mas_piano_yr_prac:
     m 1a "That was really cool, [player]!"
     m 3b "With some more practice, you'll be able to play my song perfectly."
     m 1j "Make sure to practice everyday for me, okay~?"
@@ -345,38 +341,85 @@ init -3 python in mas_piano_keys:
         B5: B5,
         C6: C6
     }
-
-
-    # 1:1 keymap setup. This is the actual keymap that gets used. The
-    # persistent is just the adjustments
-    live_keymap = {
-        F4: F4,
-        F4SH: F4SH,
-        G4: G4,
-        G4SH: G4SH,
-        A4: A4,
-        A4SH: A4SH,
-        B4: B4,
-        C5: C5,
-        C5SH: C5SH,
-        D5: D5,
-        D5SH: D5SH,
-        E5: E5,
-        F5: F5,
-        F5SH: F5SH,
-        G5: G5,
-        G5SH: G5SH,
-        A5: A5,
-        A5SH: A5SH,
-        B5: B5,
-        C6: C6
-    }
         
     # blacklisted keys
     BLACKLIST = (
-        ESC
+        ESC,
+        pygame.K_MODE,
+        pygame.K_HELP,
+        pygame.K_PRINT,
+        pygame.K_SYSREQ,
+        pygame.K_BREAK,
+        pygame.K_MENU,
+        pygame.K_POWER,
+        pygame.K_EURO
 #        pygame.K_DELETE
     )
+
+    # noncharable keymaps and display text dict
+    NONCHAR_TEXT = {
+        pygame.K_BACKSPACE: "\\b",
+        pygame.K_TAB: "\\t",
+        pygame.K_CLEAR: "Cr",
+        pygame.K_RETURN: "\\r",
+        pygame.K_PAUSE: "Pa",
+        pygame.K_DELETE: "Dl",
+        pygame.K_KP0: "K0",
+        pygame.K_KP1: "K1",
+        pygame.K_KP2: "K2",
+        pygame.K_KP3: "K3",
+        pygame.K_KP4: "K4",
+        pygame.K_KP5: "K5",
+        pygame.K_KP6: "K6",
+        pygame.K_KP7: "K7",
+        pygame.K_KP8: "K8",
+        pygame.K_KP9: "K9",
+        pygame.K_KP_PERIOD: "K.",
+        pygame.K_KP_DIVIDE: "K/",
+        pygame.K_KP_MULTIPLY: "K*",
+        pygame.K_KP_MINUS: "K-",
+        pygame.K_KP_PLUS: "K+",
+        pygame.K_KP_ENTER: "Kr",
+        pygame.K_KP_EQUALS: "K=",
+        pygame.K_UP: "Up",
+        pygame.K_DOWN: "Dn",
+        pygame.K_RIGHT: "Rg",
+        pygame.K_LEFT: "Lf",
+        pygame.K_INSERT: "In",
+        pygame.K_HOME: "Hm",
+        pygame.K_END: "En",
+        pygame.K_PAGEUP: "PU",
+        pygame.K_PAGEDOWN: "PD",
+        pygame.K_F1: "F1",
+        pygame.K_F2: "F2",
+        pygame.K_F3: "F3",
+        pygame.K_F4: "F4",
+        pygame.K_F5: "F5",
+        pygame.K_F6: "F6",
+        pygame.K_F7: "F7",
+        pygame.K_F8: "F8",
+        pygame.K_F9: "F9",
+        pygame.K_F10: "10",
+        pygame.K_F11: "11",
+        pygame.K_F12: "12",
+        pygame.K_F13: "13",
+        pygame.K_F14: "14",
+        pygame.K_F15: "15",
+        pygame.K_NUMLOCK: "NL",
+        pygame.K_CAPSLOCK: "CL",
+        pygame.K_SCROLLOCK: "SL",
+        pygame.K_RSHIFT: "RS",
+        pygame.K_LSHIFT: "LS",
+        pygame.K_RCTRL: "RC",
+        pygame.K_LCTRL: "LC",
+        pygame.K_RALT: "RA",
+        pygame.K_LALT: "LA",
+        pygame.K_RMETA: "RM",
+        pygame.K_LMETA: "LM",
+        pygame.K_RSUPER: "RW",
+        pygame.K_LSUPER: "LW"
+    }
+
 
 # FUNCTIONS ===================================================================
 
@@ -397,34 +440,10 @@ init -3 python in mas_piano_keys:
             persistent._mas_piano_keymaps
         """
         for k in renpy.game.persistent._mas_piano_keymaps:
-            if k[v] == value:
+            if renpy.game.persistent._mas_piano_keymaps[k] == value:
                 return k
 
         return None
-
-
-    def _initKeymap(adjustments):
-        """
-        Edits the keymap stored here with the given dict of keymap adjustments.
-        NOTE: will reset the internal keymap before applying adjustments, so
-        make sure to apply _all_ the adjustments you want at once
-
-        IN:
-            adjustments - dict of keymap adjustments:
-                key : keymap value (which is reflected as a KEYMAP value)
-
-        ASSUMES:
-            KEYMAP - the defaults keymap
-            live_keymap - the keymap we change
-        """
-        # reset the keymaps
-        live_keymap = dict(KEYMAP)
-
-        # now apply adjustments
-        for k in adjustments:
-            if adjustments[k] in live_keymap:
-                live_keymap.pop(adjustments[k])
-            live_keymap[k] = adjustments[k]
 
 
     def _setKeymap(key, new):
@@ -435,6 +454,10 @@ init -3 python in mas_piano_keys:
         IN:
             key - the key we are mapping
             new - the new key item to map to
+
+        RETURNS: tuple of the following format:
+            [0] - new key that was set (could be None)
+            [1] - old key that was originally set (could be None)
 
         ASSUMES:
             persistent._mas_piano_keymaps
@@ -448,6 +471,9 @@ init -3 python in mas_piano_keys:
         # only add a keymap if its different
         if key != new:
             renpy.game.persistent._mas_piano_keymaps[new] = key
+            return (new, old_key)
+
+        return (None, old_key)
 
 
 # CLASSES =====================================================================
@@ -1238,10 +1264,10 @@ init 1000 python in mas_piano_keys:
         ],
         [0, 8, 15, 23],
         "Your Reality",
-        "zz_piano_yr_win",
-        "zz_piano_yr_fc",
-        "zz_piano_yr_fail",
-        "zz_piano_yr_prac",
+        "mas_piano_yr_win",
+        "mas_piano_yr_fc",
+        "mas_piano_yr_fail",
+        "mas_piano_yr_prac",
         5.0
 #        "zz_piano_yr_launch"
     )
@@ -1585,6 +1611,27 @@ init 1001 python:
             pygame.MOUSEBUTTONDOWN,
             pygame.MOUSEBUTTONUP
         )
+
+        # keymap text overlays
+        # these are supposed to be off so you can tell which keys are custom
+        # and which are default
+        # x coords are same as black keys (which vary)
+        # black ones
+        KMP_TXT_OVL_B_Y = ZZPK_IMG_BACK_Y 
+        KMP_TXT_OVL_B_W = ZZPK_IMG_EKEY_WIDTH
+        KMP_TXT_OVL_B_H = 47
+        KMP_TXT_OVL_B_BGCLR = "#4D4154"
+        KMP_TXT_OVL_B_FGCLR = "#14001E"
+
+        # white ones
+        KMP_TXT_OVL_W_X = ZZPK_IMG_KEYS_X
+        KMP_TXT_OVL_W_Y = ZZPK_IMG_BACK_Y + 281
+        KMP_TXT_OVL_W_W = ZZPK_IMG_IKEY_WIDTH
+        KMP_TXT_OVL_W_H = 41
+        KMP_TXT_OVL_W_BGCLR = "#14001E"
+        KMP_TXT_OVL_W_FGCLR = "#4D4154"
+
+        KMP_TXT_OVL_FONT = "gui/font/Halogen.ttf"
 
         def __init__(self, mode, pnml=None):
             """
@@ -1944,6 +1991,22 @@ init 1001 python:
                 (mas_piano_keys.A5SH, 406)
             ]
 
+            # keymap text overlays
+            self._kmp_txt_ovl_b_bg = Solid(
+                self.KMP_TXT_OVL_B_BGCLR,
+                xsize=self.KMP_TXT_OVL_B_W,
+                ysize=self.KMP_TXT_OVL_B_H
+            )
+            self._kmp_txt_ovl_w_bg = Solid(
+                self.KMP_TXT_OVL_W_BGCLR,
+                xsize=self.KMP_TXT_OVL_W_W,
+                ysize=self.KMP_TXT_OVL_W_H
+            )
+
+            # keymap text overlays dict
+            # key : MASButtonDisplayable
+            self._keymap_overlays = dict()
+
             # overlay dict
             # NOTE: x and y are assumed to be relative to the top let of
             #   the piano_back image
@@ -2077,11 +2140,17 @@ init 1001 python:
             # config mode, selected overlay (which contains the key)
             self._sel_ovl = None
 
+            # live keymaps (the one we actually use
+            self.live_keymap = None
+
             # setting up premature button stuff
             if len(persistent._mas_piano_keymaps) == 0:
                 self._button_resetall.disable()
+                self.live_keymap = dict(mas_piano_keys.KEYMAP)
             else:
-                mas_piano_keys._initKeymap(persistent._mas_piano_keymaps)
+                self._initKeymap()
+                for key in persistent._mas_piano_keymaps:
+                    self._keymap_overlays[key] = self._buildKeyTextOverlay(key)
 
             # this should be disabled at start
             self._button_cancel.disable()
@@ -2126,6 +2195,92 @@ init 1001 python:
 #            else:
 #                self.redraw_count += 1
 #                renpy.redraw(self, timeout)
+
+
+        def _buildKeyTextOverlay(self, key):
+            """
+            Builds a keytext overlay for a key. This will check the keymaps
+            for the associated actual key and set everything up approptiately.
+            Assumes the given key has a keymap
+
+            IN:
+                key - the key to build a keytextoverlay for (the key user will
+                    press)
+
+            RETURNS:
+                MASButtonDisplayable of the text overlay. All states of this
+                button will be the same.
+            """
+            # get the actual button to determine if white or black key
+            real_key = self.live_keymap[key]
+            config_ovl_button = self._config_overlays[real_key]
+            if key in mas_piano_keys.NONCHAR_TEXT:
+                text_key = mas_piano_keys.NONCHAR_TEXT[key]
+            else:
+                text_key = chr(key).upper()
+
+            if config_ovl_button.height == self.ZZPK_IMG_EKEY_HEIGHT:
+                # this is a black key
+                ovl_text = Text(
+                    text_key,
+                    font=self.KMP_TXT_OVL_FONT,
+                    size=gui.text_size,
+                    color=self.KMP_TXT_OVL_B_FGCLR,
+                    outlines=[]
+                )
+                return MASButtonDisplayable(
+                    ovl_text,
+                    ovl_text,
+                    ovl_text,
+                    self._kmp_txt_ovl_b_bg,
+                    self._kmp_txt_ovl_b_bg,
+                    self._kmp_txt_ovl_b_bg,
+                    config_ovl_button.xpos,
+                    self.KMP_TXT_OVL_B_Y,
+                    self.KMP_TXT_OVL_B_W,
+                    self.KMP_TXT_OVL_B_H
+                )
+
+            else:
+                # this is a white key
+                ovl_text = Text(
+                    text_key,
+                    font=self.KMP_TXT_OVL_FONT,
+                    size=gui.text_size,
+                    color=self.KMP_TXT_OVL_W_FGCLR,
+                    outlines=[]
+                )
+                return MASButtonDisplayable(
+                    ovl_text,
+                    ovl_text,
+                    ovl_text,
+                    self._kmp_txt_ovl_w_bg,
+                    self._kmp_txt_ovl_w_bg,
+                    self._kmp_txt_ovl_w_bg,
+                    config_ovl_button.xpos,
+                    self.KMP_TXT_OVL_W_Y,
+                    self.KMP_TXT_OVL_W_W,
+                    self.KMP_TXT_OVL_W_H
+                )
+
+
+        def _initKeymap(self):
+            """
+            Initalizes the keymap, applying persistent adjustments.
+
+            ASSUMES:
+                persistent._mas_piano_keymaps
+                mas_piano_keys.KEYMAP - the defaults keymap
+                self.live_keymap - the keymap we use
+            """
+            # reset the keymaps
+            self.live_keymap = dict(mas_piano_keys.KEYMAP)
+
+            # now apply adjustments
+            for key,real_key in persistent._mas_piano_keymaps.iteritems():
+                if real_key in self.live_keymap:
+                    self.live_keymap.pop(real_key)
+                self.live_keymap[key] = real_key
 
     
         def _sendEventsToOverlays(self, ev, x, y, st):
@@ -2286,7 +2441,7 @@ init 1001 python:
             completed_pnms = 0
 
             if not self.note_hit:
-                end_label = "zz_piano_none"
+                end_label = "mas_piano_result_none"
 
             elif self.pnml:
                 full_combo = True
@@ -2328,7 +2483,7 @@ init 1001 python:
                     is_prac = True
 
             else:
-                end_label = "zz_piano_default"
+                end_label = "mas_piano_result_default"
 
             # finally return the tuple
             return (
@@ -2618,6 +2773,18 @@ init 1001 python:
                         )
                     )
 
+            # prepare keytext overlays
+            keytext_overlays = [
+                (
+                    self._keymap_overlays[key].render(
+                        width, height, st, at
+                    ),
+                    self._keymap_overlays[key].xpos,
+                    self._keymap_overlays[key].ypos
+                )
+                for key in self._keymap_overlays
+            ]
+
             # Draw the piano
             r.blit(
                 back,
@@ -2643,6 +2810,10 @@ init 1001 python:
                         self.ZZPK_IMG_BACK_Y + ovl[2]
                     )
                 )
+
+            # keytext overlays
+            for ovl,x,y in keytext_overlays:
+                r.blit(ovl, (x, y))
 
             # True if we need to do an interaction restart
             restart_int = False
@@ -2956,13 +3127,14 @@ init 1001 python:
                     if clicked_done is not None:
                         # done was clicked, return to regular gameplay
                         self.state = self.STATE_CLEAN
-                        mas_piano_keys._initKeymap(persistent._mas_piano_keymaps)
 
                     elif clicked_resetall is not None:
                         # reset all keymaps
                         # TODO: ask are you sure
                         persistent._mas_piano_keymaps = dict()
+                        self._initKeymap()
                         self._button_resetall.disable()
+                        self._keymap_overlays = dict()
 
                     elif clicked_ovl is not None:
                         # we've clicked a key, save that value and switch to
@@ -3004,12 +3176,14 @@ init 1001 python:
                         
                         if old_key:
                             persistent._mas_piano_keymaps.pop(old_key)
+                            self._keymap_overlays.pop(old_key)
 
                         self.state = self.STATE_CONFIG_WAIT
                         self._button_done.enable()
                         self._button_cancel.disable()
                         self._button_reset.disable()
                         self.pressed[self._sel_ovl.return_value] = False
+                        self._initKeymap()
 
                 # regular states
                 else:
@@ -3036,10 +3210,15 @@ init 1001 python:
 
                 if self.state == self.STATE_CONFIG_CHANGE:
                     # blacklisted keys cannot be used
-                    if ev.key not in mas_piano_keys.BLACKLIST:
+                    if (
+                            ev.key not in mas_piano_keys.BLACKLIST
+                            and (ev.key in mas_piano_keys.NONCHAR_TEXT
+                                or 0 <= ev.key <= 255
+                            )
+                        ):
 
                         # set keymap
-                        mas_piano_keys._setKeymap(
+                        new_key, old_key = mas_piano_keys._setKeymap(
                             self._sel_ovl.return_value,
                             ev.key
                         )
@@ -3050,20 +3229,32 @@ init 1001 python:
                         self._button_cancel.disable()
                         self._button_reset.disable()
                         self.pressed[self._sel_ovl.return_value] = False
+                        self._initKeymap()
 
+                        # resetall enabled if we have keymaps
                         if len(persistent._mas_piano_keymaps) > 0:
                             self._button_resetall.enable()
                         else:
                             self._button_resetall.disable()
 
+                        # update keymap overlays
+                        if old_key in self._keymap_overlays:
+                            self._keymap_overlays.pop(old_key)
+                        if new_key:
+                            self._keymap_overlays[new_key] = (
+                                self._buildKeyTextOverlay(new_key)
+                            )
+
+                        renpy.play(
+                            self.pkeys[self._sel_ovl.return_value], 
+                            channel="audio"
+                        )
+
                         renpy.redraw(self, 0)
 
                 else:
                     # check for mapping
-                    if self.state == self.STATE_CONFIG_WAIT:
-                        key = persistent._mas_piano_keymaps(ev.key, ev.key)
-                    else:
-                        key = mas_piano_keys.live_keymap.get(ev.key, ev.key)
+                    key = self.live_keymap.get(ev.key, None)
 
                     if self.state not in self.CONFIG_STATES:
                         # regular game mode only
@@ -3120,7 +3311,7 @@ init 1001 python:
             elif ev.type == pygame.KEYUP:
 
                 # check for mapping
-                key = mas_piano_keys.live_keymap.get(ev.key, ev.key)
+                key = self.live_keymap.get(ev.key, None)
 
                 # only do this if we keyup a key we care about
                 if self.pressed.get(key, False):

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -128,6 +128,10 @@ label zz_play_piano_setupstart:
 label zz_play_piano_loopend:
     return
 
+
+label mas_piano_configure:
+    return
+
 ### labels for piano states ===================================================
 
 # default. post game, freestyle mode
@@ -2452,6 +2456,11 @@ init 1001 python:
         BUTTON_CANCEL = 1
         BUTTON_RESET = 2
 
+        # button stuff
+        BUTTON_SPACING = 10
+        BUTTON_WIDTH = 120
+        BUTTON_HEIGHT = 35
+
         def __init__(self):
             """
             Constructor for the piano displayable setup class
@@ -2460,19 +2469,148 @@ init 1001 python:
             # we want to be in setup mode
             super(PianoDisplayable, self).__init__(self.MODE_SETUP)
 
-            # buttons
-            self.button_w = 120
-            self.button_h = 35
-            self.button_idle = Image("mod_assets/hkb_idle_background")
-            self.button_hover = Image("mod_assets/hkb_hover_background")
-            self.button_disabled = Image("mod_assets/hkb_disabled_background")
+            # button backgrounds
+            # TODO: get rid of this class and move all of this code to the
+            # regular pianodisplayable. we can add 2 states to the thing
+            # so we can do configurations
+            button_idle = Image("mod_assets/hkb_idle_background")
+            button_hover = Image("mod_assets/hkb_hover_background")
+            button_disabled = Image("mod_assets/hkb_disabled_background")
 
-            # dict of button states
-            self.button_states = {
-                
+            # button text
+            button_done_text_idle = Text(
+                "Done",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_done_text_hover = Text(
+                "Done",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_cancel_text_idle = Text(
+                "Cancel",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_cancel_text_hover = Text(
+                "Cancel",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_reset_text_idle = Text(
+                "Reset",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_reset_text_hover = Text(
+                "Reset",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_resetall_text_idle = Text(
+                "Reset All",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_resetall_text_hover = Text(
+                "Reset All",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
 
-        def _decideButton(self, 
+            # calculate button locations
+            # buttons should be spaced by BUTTONS_SPACING
+            button_x_start = (
+                int((self.PIANO_BACK_WIDTH - (
+                    (self.BUTTON_WIDTH * 3) + (self.BUTTON_SPACING * 2)
+                )) / 2) + self.ZZPK_IMG_BACK_X
+            )
+            button_y_start = (self.ZZPK_IMG_BACK_Y + self.PIANO_BACK_HEIGHT +
+                self.BUTTON_SPACING
+            )
 
+            # the 4 actual buttons we have
+            self._button_done = MASButtonDisplayable(
+                button_done_text_idle,
+                button_done_text_hover,
+                button_done_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                button_x_start,
+                button_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+            self._button_cancel = MASButtonDisplayable(
+                button_cancel_text_idle,
+                button_cancel_text_hover,
+                button_cancel_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                button_x_start + self.BUTTON_WIDTH + self.BUTTON_SPACING,
+                button_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+            self._button_reset = MASButtonDisplayable(
+                button_reset_text_idle,
+                button_reset_text_hover,
+                button_reset_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                button_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
+                button_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+            self._button_resetall = MASButtonDisplayable(
+                button_resetall_text_idle,
+                button_resetall_text_hover,
+                button_resetall_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                button_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
+                button_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+
+            # list of always visible buttons
+            self._always_visible = [
+                self._button_done,
+                self._button_cancel
+            ]
+               
+            self.state = self.STATE_WAIT
 
         def _setKeymap(self, keydex, new, old=None):
             """
@@ -2522,23 +2660,33 @@ init 1001 python:
                         )
                     )
 
-            # TODO: prepare button/image maps
-            # 4 buttons:
-            # DONE - quits the piano setup mode
-            #   always on
-            # CANCEL - undos a change
-            #   only clickable if a key has been pressed and is ready for
-            #   change
-            # SAVE - saves a key press NOTE: dont need this probably
-            #   only clickable if a key has been pressed and is ready for
-            #   change
-            # RESET / RESET ALL - resets the key
-            #   RESET - resets one key
-            #       only clickable if a key has been pressed and is ready
-            #       for change
-            #   RESET ALL - resets all keys
-            #       only clickable if no key has been pressed
             # render buttons
+            visible_buttons = [
+                (
+                    renpy.render(b, width, height, st, at),
+                    b.xpos,
+                    b.ypos
+                )
+                for b in self._always_visible
+            ]
+
+            if self.state == self.STATE_WAIT:
+                visible_buttons.append((
+                    renpy.render(
+                        self._button_resetall, width, height, st, at
+                    ),
+                    self._button_resetall.xpos,
+                    self._button_resetall.ypos
+                ))
+
+            else: # in chagne state
+                visible_buttons.append((
+                    renpy.render(
+                        self._button_reset, width, height, st, at
+                    ),
+                    self._button_reset.xpos,
+                    self._button_reset.ypos
+                ))
 
             # Draw the piano
             r.blit(
@@ -2557,7 +2705,6 @@ init 1001 python:
             )
 
             # and now the overlays
-            # TODO: render the letter mapping (if possible)
             for ovl in overlays:
                 r.blit(
                     ovl[0],
@@ -2567,9 +2714,12 @@ init 1001 python:
                     )
                 )
 
+            # and finally visible buttons
+            for vis_b in visible_buttons:
+                r.blit(vis_b[0], (vis_b[1], vis_b[2]))
+
             # return the render object
             return r
-
 
 
         def event(self, ev, x, y, st):
@@ -2577,9 +2727,22 @@ init 1001 python:
             Event handler for the PianoSetupDisplayable
             """
 
+            # pass all mouse events to the children
+            # TODO: move these to appropraite state checking
+            done = self._button_done.event(ev, x, y, st)
+            cancel = self._button_cancel.event(ev, x, y, st)
+            if self.state == self.STATE_WAIT:
+                reset = self._button_reset.event(ev, x, y, st)
+            else:
+                reset = self._button_resetall.event(ev, x, y, st)
+
             if ev.type == pygame.KEYDOWN:
                 if ev.key == zzpianokeys.QUIT: # z for now
                     return 100
+                elif ev.key == pygame.K_q:
+                    self.state = self.STATE_CHANGE
+                elif ev.key == pygame.K_w:
+                    self.state = self.STATE_WAIT
 
             # continous event
             raise renpy.IgnoreEvent()

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -1428,6 +1428,9 @@ init 1001 python:
         ZZPK_IMG_KEYS_Y = 50
         ZZPK_LYR_BAR_YOFF = -50
 
+        # offset for hit location
+        ZZPK_IMG_IKEY_YOFF = 152
+
         # other sizes
         ZZPK_IMG_IKEY_WIDTH = 36
         ZZPK_IMG_IKEY_HEIGHT = 214
@@ -2694,10 +2697,15 @@ init 1001 python:
                         self._button_resetall.disable()
 
                     # TODO: check for click on a piano key
-                    # TODO: change the piano keys to use MASButtonDisplayable
-                    # so this part can be way simpler
+                    # TODO: add MASButtonDisplayables for click overlays.
+                    # these should just be solid colors, when the mouse is over
+                    # them they should turn pink. Clicking on the overlay
+                    # will visibly depress the key and switch to CHANGE state
                     # TODO: on a piano key click, the done button should be
                     # disabled and the current key should be saved
+                    # NOTE: colors:
+                    # black overlay #0005
+                    # hover overlay #ffe6f4AA
 
                 # config change
                 elif self.state == self.STATE_CONFIG_CHANGE:

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -1298,6 +1298,18 @@ init 1001 python:
         # NOTE: CALLS REDRAW
         STATE_WDONE = 14
 
+        # CONFIGuration WAIT state. This is for configuration mode, waiting
+        # for the user to click something. The user can hit the keys and play
+        # sounds, but thats about it. If the user clicks a key with mouse,
+        # the key is pressed and we enter CHANGE.
+        # when user clicks Done, we go back to LISTEN state.
+        STATE_CONFIG_WAIT = 15
+
+        # CONFIGuration CHANGE state. This is for configuration mode. User
+        # has selected a key, and now we want to set it to the next key the
+        # user presses.
+        STATE_CONFIG_CHANGE = 16
+
         # TUPLE state groups. This for easier checking of states
         # States related to Done flow
         DONE_STATES = (
@@ -1354,6 +1366,12 @@ init 1001 python:
         FINAL_DONE_STATES = (
             STATE_DONE,
             STATE_WDONE
+        )
+
+        # configuration states
+        CONFIG_STATES = (
+            STATE_CONFIG_WAIT,
+            STATE_CONFIG_CHANGE
         )
 
         # key limit for matching
@@ -1415,6 +1433,11 @@ init 1001 python:
         MODE_FREE = 0
         MODE_SONG = 1 # song mode means we are trying to play a song
 
+        # button stuff
+        BUTTON_SPACING = 10
+        BUTTON_WIDTH = 120
+        BUTTON_HEIGHT = 35
+
         def __init__(self, mode, pnml=None):
             """
             Creates the piano displablable
@@ -1439,6 +1462,214 @@ init 1001 python:
 
             # lyric bar
             self.lyrical_bar = Image(self.ZZPK_LYR_BAR)
+
+            # button shit
+            button_idle = Image("mod_assets/hkb_idle_background.png")
+            button_hover = Image("mod_assets/hkb_hover_background.png")
+            button_disabled = Image("mod_assets/hkb_disabled_background.png")
+
+            # button text
+            button_done_text_idle = Text(
+                "Done",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_done_text_hover = Text(
+                "Done",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_cancel_text_idle = Text(
+                "Cancel",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_cancel_text_hover = Text(
+                "Cancel",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_reset_text_idle = Text(
+                "Reset",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_reset_text_hover = Text(
+                "Reset",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_resetall_text_idle = Text(
+                "Reset All",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_resetall_text_hover = Text(
+                "Reset All",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_config_text_idle = Text(
+                "Config",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_config_text_hover = Text(
+                "Config",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+            button_quit_text_idle = Text(
+                "Quit",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_quit_text_hover = Text(
+                "Quit",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+
+            # calculate button locations
+            # buttons should be spaced by BUTTONS_SPACING
+            cbutton_x_start = (
+                int((self.PIANO_BACK_WIDTH - (
+                    (self.BUTTON_WIDTH * 3) + (self.BUTTON_SPACING * 2)
+                )) / 2) + self.ZZPK_IMG_BACK_X
+            )
+            cbutton_y_start = (
+                self.ZZPK_IMG_BACK_Y + 
+                self.PIANO_BACK_HEIGHT +
+                self.BUTTON_SPACING
+            )
+            pbutton_x_start = (
+                int((self.PIANO_BACK_WIDTH - (
+                    (self.BUTTON_WIDTH * 2) + self.BUTTON_SPACING
+                )) / 2) + self.ZZPK_IMG_BACK_X
+            )
+            pbutton_y_start = cbutton_y_start
+
+            # the 4 config buttons we have
+            self._button_done = MASButtonDisplayable(
+                button_done_text_idle,
+                button_done_text_hover,
+                button_done_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                cbutton_x_start,
+                cbutton_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+            self._button_cancel = MASButtonDisplayable(
+                button_cancel_text_idle,
+                button_cancel_text_hover,
+                button_cancel_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                cbutton_x_start + self.BUTTON_WIDTH + self.BUTTON_SPACING,
+                cbutton_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+            self._button_reset = MASButtonDisplayable(
+                button_reset_text_idle,
+                button_reset_text_hover,
+                button_reset_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                cbutton_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
+                cbutton_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+            self._button_resetall = MASButtonDisplayable(
+                button_resetall_text_idle,
+                button_resetall_text_hover,
+                button_resetall_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                button_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
+                button_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+
+            # the config button
+            self._button_config = MASButtonDisplayable(
+                button_config_text_idle,
+                button_config_text_hover,
+                button_config_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                pbutton_x_start,
+                pbutton_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+            self._button_quit = MASButtonDisplayable(
+                button_quit_text_idle,
+                button_quit_text_hover,
+                button_quit_text_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                pbutton_x_start + self.BUTTON_WIDTH + self.BUTTON_SPACING,
+                pbutton_y_start,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+
+            # list of always visible buttons
+            self._always_visible_config = [
+                self._button_done,
+                self._button_cancel
+            ]
+            self._always_visible_play = [
+                self._button_config,
+                self._button_quit
+            ]
 
             # setup sounds
             # sound dict:
@@ -1645,6 +1876,31 @@ init 1001 python:
 #            else:
 #                self.redraw_count += 1
 #                renpy.redraw(self, timeout)
+
+
+        def _setKeymap(self, keydex, new, old=None):
+            """
+            Sets a keymap. If old is None, it is assumed that we are adding
+            a new keymap and not replacing an existing one.
+
+            IN:
+                keydex - the index of the key value
+                new - the new key item to map to
+                old - old key item (the one to map)
+                    (Default: None)
+
+            ASSUMES:
+                persistent.piano_keys
+                zzpianokeys.KEYORDER
+            """
+            if old and old in persistent.piano_keys:
+                key_value = persistent.piano_keys.pop(old)
+            else:
+                key_value = zzpianokeys.KEYORDER[keydex]
+
+            # only add a keymap if its different
+            if key_value != new:
+                persistent.piano_keys[new] = key_value
 
 
         def findnotematch(self, notes):
@@ -2049,605 +2305,6 @@ init 1001 python:
             back = renpy.render(self.piano_back, 1280, 720, st, at)
             piano = renpy.render(self.piano_keys, 1280, 720, st, at)
 
-
-            # now prepare overlays to render
-            overlays = list()
-            for k in self.pressed:
-                if self.pressed[k]:
-                    overlays.append(
-                        (
-                            renpy.render(self.overlays[k][0], 1280, 720, st, at),
-                            self.overlays[k][1],
-                            self.overlays[k][2]
-                        )
-                    )
-
-            # Draw the piano
-            r.blit(
-                back,
-                (
-                    self.ZZPK_IMG_BACK_X,
-                    self.ZZPK_IMG_BACK_Y
-                )
-            )
-            r.blit(
-                piano,
-                (
-                    self.ZZPK_IMG_KEYS_X + self.ZZPK_IMG_BACK_X,
-                    self.ZZPK_IMG_KEYS_Y + self.ZZPK_IMG_BACK_Y
-                )
-            )
-
-            # and now the overlays
-            for ovl in overlays:
-                r.blit(
-                    ovl[0],
-                    (
-                        self.ZZPK_IMG_BACK_X + ovl[1],
-                        self.ZZPK_IMG_BACK_Y + ovl[2]
-                    )
-                )
-
-            # True if we need to do an interaction restart
-            restart_int = False
-
-            # True if we already called a redraw
-            redrawn = False
-
-            # subtract a redraw count for every render
-#            if self.redraw_count > 0:
-#                self.redraw_count -= 1
-
-            # check if we are currently matching something
-            # NOTE: the following utilizies renpy.show, which means we need
-            #   to use renpy.restart_interaction(). This also means that the
-            #   changes that occur here shouldnt be rendered
-            # STATE MACHINE
-            if self.state in self.DONE_STATES:
-
-                if self.state == self.STATE_DJPOST:
-                    # display monikas post expression
-                    renpy.show(self.match.postexpress)
-
-                    # hide text
-                    if not self.match.posttext:
-                        self.lyric = None
-
-                    restart_int = True
-
-                    # we go to DPOST instead of POST
-                    self.state = self.STATE_DPOST
-
-                    # force a redraw
-                    renpy.redraw(self, self.vis_timeout)
-
-                # check for visual timeout
-                elif st-self.prev_time >= self.vis_timeout:
-
-                    # force event call
-                    self.state = self.STATE_DONE
-                    renpy.timeout(1.0)
-#                    renpy.redraw(self, 1.0)
-#                    redrawn = True
-
-                # do a redraw for the next timeout
-                else:
-                    renpy.redraw(self, self.vis_timeout)
-#                    redrawn = True
-
-            elif (
-                    self.state == self.STATE_CLEAN
-                    or st-self.prev_time >= self.ev_timeout
-                ):
-
-                # default monika
-                renpy.show(self.DEFAULT)
-
-                # hide text
-                self.lyric = None
-
-                restart_int = True
-
-                if self.state not in self.DONE_STATES:
-                    self.state = self.STATE_LISTEN
-                    self.resetVerse()
-                self.setsongmode(False)
-
-            elif self.state != self.STATE_LISTEN:
-
-                if self.state == self.STATE_JMATCH:
-
-                    # display monika's expression
-                    renpy.show(self.match.express)
-
-                    # display text
-                    self.lyric = self.match.say
-
-                    # set song mode
-                    self.setsongmode(vis_tout=self.match.vis_timeout)
-
-                    restart_int = True
-                    self.state = self.STATE_MATCH
-
-                elif self.state == self.STATE_MISS:
-
-                    # display an awkward expresseion monika
-                    renpy.show(self.AWKWARD)
-                    restart_int = True
-
-                elif self.state == self.STATE_VPOST:
-
-                    # display the post expression
-                    renpy.show(self.lastmatch.postexpress)
-                    restart_int = True
-
-                    # hide text
-                    if not self.lastmatch.posttext:
-                        self.lyric = None
-
-                    # setup visual timeout
-                    if self.lastmatch.vis_timeout:
-#                        self.customRedraw(
-#                            self.lastmatch.redraw_time,
-#                            from_render=True
-#                        )
-                        renpy.redraw(self, self.lastmatch.vis_timeout)
-                        self.drawn_time = st
-                        self.state = self.STATE_CPOST
-                        redrawn = True
-
-                    else:
-                        self.state = self.STATE_WPOST
-
-                elif self.state == self.STATE_CPOST:
-
-                    # check if timeout
-                    if st-self.drawn_time >= self.lastmatch.vis_timeout:
-
-                        # display default monika
-                        renpy.show(self.DEFAULT)
-
-                        # hide text
-                        self.lyric = None
-
-                        restart_int = True
-                        self.state = self.STATE_WPOST
-
-                    # force a redraw in a second
-                    else:
-#                        self.customRedraw(1.0, from_render=True)
-                        renpy.redraw(self, 1.0)
-                        redrawn = True
-
-                elif self.state == self.STATE_JPOST:
-
-                    # display monikas post expression
-                    renpy.show(self.match.postexpress)
-
-                    # hide text
-                    if not self.match.posttext:
-                        self.lyric = None
-
-                    restart_int = True
-                    self.state = self.STATE_POST
-
-                elif self.state == self.STATE_FAIL:
-
-                    # display failed monika
-                    renpy.show(self.FAILED)
-
-                    # hide text
-                    self.lyric = None
-
-                    restart_int = True
-                    self.state = self.STATE_CLEAN
-
-                # redraw timeout
-                if not redrawn:
-                    renpy.redraw(self, self.vis_timeout)
-#                    self.customRedraw(self.vis_timeout, from_render=True)
-
-            if self.lyric:
-                lyric_bar = renpy.render(self.lyrical_bar, 1280, 720, st, at)
-                lyric = renpy.render(self.lyric, 1280, 720, st, at)
-                pw, ph = lyric.get_size()
-
-                # the lyric bar should be slightly below y-center
-                r.blit(
-                    lyric_bar,
-                    (
-                        0,
-                        int((height - 50) /2) - self.ZZPK_LYR_BAR_YOFF
-                    )
-                )
-                r.blit(
-                    lyric,
-                    (
-                        int((width - pw) / 2),
-                        int((height - ph) / 2) - self.ZZPK_LYR_BAR_YOFF
-                    )
-                )
-
-#                    renpy.show(
-#                        "monika " + match.express,
-#                        at_list=self.AT_LIST,
-#                        zorder=10,
-#                        layer="transient"
-#                    )
-#                    renpy.force_full_redraw()
-#                    r.blit(
-#                        renpy.render(match.img, 1280, 720, st, at),
-#                        (0, 0)
-#                    )
-#                    renpy.say(m, match.say, interact=False)
-#                    renpy.force_full_redraw()
-
-            if restart_int:
-                renpy.restart_interaction()
-
-            # rerender redrawing thing
-            # renpy.redraw(self, 0)
-
-            # and apparenly we return the render object
-            return r
-
-        def event(self, ev, x, y, st):
-            # renpy event handler
-            # NOTE: Renpy is EVENT-DRIVEN
-
-            # DONE state means you immediate quit
-            if self.state in self.FINAL_DONE_STATES:
-                return self.quitflow()
-
-            # when you press down a key, we launch a sound
-            if ev.type == pygame.KEYDOWN:
-
-                # check for mapping
-                key = persistent.piano_keymaps.get(ev.key, ev.key)
-
-                if len(self.played) > self.KEY_LIMIT:
-                    self.played = list()
-
-                # we only care about keydown events regarding timeout
-                elif st-self.prev_time >= self.ev_timeout:
-
-#                    self.testing.write("".join([chr(x) for x in self.played])+ "\n")
-                    self.played = list()
-
-                    # NOTE: in the listen state,  timeout means restart
-                    # the played list (which is what handles the note
-                    # matchin). Keep state.
-
-                    # NOTE: in transitional post states, timeout means
-                    # continue waiting.
-                    # Keep state.
-
-                    # NOTE: in done related states, timeout means quit
-                    # the game.
-                    if self.state in self.DONE_STATES:
-                        return self.quitflow()
-
-                    # NOTE: in the match-related states, timeout means
-                    # they failed the expression.
-                    elif self.state in self.TOUT_MATCH_STATES:
-                        self.resetVerse()
-                        self.state = self.STATE_LISTEN
-
-                    # NOTE: in post-match related states, timeout means
-                    # move onto the next expression.
-                    elif self.state in self.TOUT_POST_STATES:
-                        next_pnm = self.getnotematch()
-
-                        if next_pnm:
-                            self.setsongmode(
-                                ev_tout=next_pnm.ev_timeout,
-                                vis_tout=self.match.vis_timeout
-                            )
-                            self.state = self.STATE_WPOST
-                            self.match = next_pnm
-                            self.match.matchdex = 0
-
-                        # no more matches, we are done
-                        else:
-                            self.state = self.STATE_WDONE
-
-                    # NOTE: in clean state, chnage state to listen.
-                    elif self.state == self.STATE_CLEAN:
-                        self.state = self.STATE_LISTEN
-
-#   DEBUG: NOTE:
-#                if self.match:
-#                    self.testing.write(
-#                        chr(ev.key) + " : " + str(self.state) + " : " +
-#                        str(self.match.matchdex) + "\n")
-#                else:
-#                    self.testing.write(chr(ev.key) + " : " + str(self.state) + "\n")
-
-                # setup previous time thing
-                self.prev_time = st
-
-                # but first, check for quit ("Z")
-                if key == zzpianokeys.QUIT:
-                    return self.quitflow()
-                else:
-
-                    # only play a sound if we've lifted the finger
-                    if not self.pressed.get(key, True):
-
-                        # note has been hit
-                        self.note_hit = True
-
-                        # add to played
-                        self.played.append(key)
-
-                        # set appropriate value
-                        self.pressed[key] = True
-
-                        # check if we have enough played notes
-                        if self.state == self.STATE_LISTEN:
-                            self.stateListen(ev, key)
-
-                        # post match checking
-                        elif self.state in self.POST_STATES:
-                            self.statePost(ev, key)
-
-                        # waiting post
-                        elif self.state in self.TRANS_POST_STATES:
-                            self.stateWaitPost(ev, key)
-
-                        # match
-                        elif self.state in self.MATCH_STATES:
-                            self.stateMatch(ev, key)
-
-                        # get a sound to play
-                        renpy.play(self.pkeys[key], channel="audio")
-
-                        # now rerender
-#                        self.customRedraw(0)
-                        renpy.redraw(self, 0)
-
-            # keyup, means we should stop render
-            elif ev.type == pygame.KEYUP:
-
-                # check for mapping
-                key = persistent.piano_keymaps.get(ev.key, ev.key)
-
-                # only do this if we keyup a key we care about
-                if self.pressed.get(key, False):
-
-                    # set appropriate value
-                    self.pressed[key] = False
-
-                    # now rerender
-#                    self.customRedraw(0)
-                    renpy.redraw(self, 0)
-
-            # time event, rerender
-            elif ev.type == renpy.display.core.TIMEEVENT:
-#                self.customRedraw(0)
-                renpy.redraw(self, 0)
-
-            # the default so we can keep going
-            raise renpy.IgnoreEvent()
-
-
-# custom piano displayable class for setting up key configurations
-    class PianoSetupDisplayable(PianoDisplayable):
-        """
-        Effectively has the same constants as PianoDisplayable, but we are
-        overwriting event and render to handle custom configs
-        """
-
-        # MORE STATES (cant get enough of them)
-        # WAIT state. Here we are waiting for user interaction. We just render
-        # the piano + buttons setup and wait for the next event
-        # Clickable buttons: DONE, RESET ALL if a keymap has been changed
-        STATE_WAIT = 0 
-
-        # CHANGE state. Here the user has clicked a key, so we assume that the
-        # the next entered key should be mapped to that key. The clicked key
-        # will remain visibly pressed until the user either hits a keyboard
-        # key or clicks cancel or reset
-        # Clickable buttons: CANCEL / RESET
-        STATE_CHANGE = 1
-
-        # button names
-        BUTTON_DONE = 0
-        BUTTON_CANCEL = 1
-        BUTTON_RESET = 2
-
-        # button stuff
-        BUTTON_SPACING = 10
-        BUTTON_WIDTH = 120
-        BUTTON_HEIGHT = 35
-
-        def __init__(self):
-            """
-            Constructor for the piano displayable setup class
-            """
-
-            # we want to be in setup mode
-            super(PianoDisplayable, self).__init__(self.MODE_SETUP)
-
-            # button backgrounds
-            # TODO: get rid of this class and move all of this code to the
-            # regular pianodisplayable. we can add 2 states to the thing
-            # so we can do configurations
-            button_idle = Image("mod_assets/hkb_idle_background")
-            button_hover = Image("mod_assets/hkb_hover_background")
-            button_disabled = Image("mod_assets/hkb_disabled_background")
-
-            # button text
-            button_done_text_idle = Text(
-                "Done",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#000",
-                outlines=[]
-            )
-            button_done_text_hover = Text(
-                "Done",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#fa9",
-                outlines=[]
-            )
-            button_cancel_text_idle = Text(
-                "Cancel",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#000",
-                outlines=[]
-            )
-            button_cancel_text_hover = Text(
-                "Cancel",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#fa9",
-                outlines=[]
-            )
-            button_reset_text_idle = Text(
-                "Reset",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#000",
-                outlines=[]
-            )
-            button_reset_text_hover = Text(
-                "Reset",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#fa9",
-                outlines=[]
-            )
-            button_resetall_text_idle = Text(
-                "Reset All",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#000",
-                outlines=[]
-            )
-            button_resetall_text_hover = Text(
-                "Reset All",
-                font=gui.default_font,
-                size=gui.text_size,
-                color="#fa9",
-                outlines=[]
-            )
-
-            # calculate button locations
-            # buttons should be spaced by BUTTONS_SPACING
-            button_x_start = (
-                int((self.PIANO_BACK_WIDTH - (
-                    (self.BUTTON_WIDTH * 3) + (self.BUTTON_SPACING * 2)
-                )) / 2) + self.ZZPK_IMG_BACK_X
-            )
-            button_y_start = (self.ZZPK_IMG_BACK_Y + self.PIANO_BACK_HEIGHT +
-                self.BUTTON_SPACING
-            )
-
-            # the 4 actual buttons we have
-            self._button_done = MASButtonDisplayable(
-                button_done_text_idle,
-                button_done_text_hover,
-                button_done_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
-                button_x_start,
-                button_y_start,
-                self.BUTTON_WIDTH,
-                self.BUTTON_HEIGHT,
-                hover_sound=gui.hover_sound,
-                activate_sound=gui.activate_sound
-            )
-            self._button_cancel = MASButtonDisplayable(
-                button_cancel_text_idle,
-                button_cancel_text_hover,
-                button_cancel_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
-                button_x_start + self.BUTTON_WIDTH + self.BUTTON_SPACING,
-                button_y_start,
-                self.BUTTON_WIDTH,
-                self.BUTTON_HEIGHT,
-                hover_sound=gui.hover_sound,
-                activate_sound=gui.activate_sound
-            )
-            self._button_reset = MASButtonDisplayable(
-                button_reset_text_idle,
-                button_reset_text_hover,
-                button_reset_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
-                button_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
-                button_y_start,
-                self.BUTTON_WIDTH,
-                self.BUTTON_HEIGHT,
-                hover_sound=gui.hover_sound,
-                activate_sound=gui.activate_sound
-            )
-            self._button_resetall = MASButtonDisplayable(
-                button_resetall_text_idle,
-                button_resetall_text_hover,
-                button_resetall_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
-                button_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
-                button_y_start,
-                self.BUTTON_WIDTH,
-                self.BUTTON_HEIGHT,
-                hover_sound=gui.hover_sound,
-                activate_sound=gui.activate_sound
-            )
-
-            # list of always visible buttons
-            self._always_visible = [
-                self._button_done,
-                self._button_cancel
-            ]
-               
-            self.state = self.STATE_WAIT
-
-        def _setKeymap(self, keydex, new, old=None):
-            """
-            Sets a keymap. If old is None, it is assumed that we are adding
-            a new keymap and not replacing an existing one.
-
-            IN:
-                keydex - the index of the key value
-                new - the new key item to map to
-                old - old key item (the one to map)
-                    (Default: None)
-
-            ASSUMES:
-                persistent.piano_keys
-                zzpianokeys.KEYORDER
-            """
-            if old and old in persistent.piano_keys:
-                key_value = persistent.piano_keys.pop(old)
-            else:
-                key_value = zzpianokeys.KEYORDER[keydex]
-
-            # only add a keymap if its different
-            if key_value != new:
-                persistent.piano_keys[new] = key_value
-
-
-        def render(self, width, height, st, at):
-            """
-            Render function
-            """
-
-            r = renpy.Render(width, height)
-
-            # prepare piano for render
-            back = renpy.render(self.piano_back, 1280, 720, st, at)
-            piano = renpy.render(self.piano_keys, 1280, 720, st, at)
-
             # now prepare overlays to render
             overlays = list()
             for k in self.pressed:
@@ -2661,32 +2318,43 @@ init 1001 python:
                     )
 
             # render buttons
-            visible_buttons = [
-                (
-                    renpy.render(b, width, height, st, at),
-                    b.xpos,
-                    b.ypos
-                )
-                for b in self._always_visible
-            ]
+            if self.state in self.CONFIG_STATES:
+                visible_buttons = [
+                    (
+                        b.render(width, height, st, at),
+    #                    renpy.render(b, width, height, st, at),
+                        b.xpos,
+                        b.ypos
+                    )
+                    for b in self._always_visible_config
+                ]
 
-            if self.state == self.STATE_WAIT:
-                visible_buttons.append((
-                    renpy.render(
-                        self._button_resetall, width, height, st, at
-                    ),
-                    self._button_resetall.xpos,
-                    self._button_resetall.ypos
-                ))
+                if self.state == self.STATE_CONFIG_WAIT:
+                    visible_buttons.append((
+                        renpy.render(
+                            self._button_resetall, width, height, st, at
+                        ),
+                        self._button_resetall.xpos,
+                        self._button_resetall.ypos
+                    ))
 
-            else: # in chagne state
-                visible_buttons.append((
-                    renpy.render(
-                        self._button_reset, width, height, st, at
+                elif self.state == self.STATE_CONFIG_CHANGE:
+                    visible_buttons.append((
+                        renpy.render(
+                            self._button_reset, width, height, st, at
+                        ),
+                        self._button_reset.xpos,
+                        self._button_reset.ypos
+                    ))
+            else:
+                visible_buttons = [
+                    (
+                        b.render(width, height, st, at),
+                        b.xpos,
+                        b.ypos
                     ),
-                    self._button_reset.xpos,
-                    self._button_reset.ypos
-                ))
+                    for b in self._always_visible_play
+                ]
 
             # Draw the piano
             r.blit(
@@ -2718,31 +2386,373 @@ init 1001 python:
             for vis_b in visible_buttons:
                 r.blit(vis_b[0], (vis_b[1], vis_b[2]))
 
-            # return the render object
+            # True if we need to do an interaction restart
+            restart_int = False
+
+            if self.state in self.CONFIG_STATES: 
+                # todo something
+                pass
+
+            else:
+
+                # True if we already called a redraw
+                redrawn = False
+
+                # subtract a redraw count for every render
+    #            if self.redraw_count > 0:
+    #                self.redraw_count -= 1
+
+                # check if we are currently matching something
+                # NOTE: the following utilizies renpy.show, which means we need
+                #   to use renpy.restart_interaction(). This also means that the
+                #   changes that occur here shouldnt be rendered
+                # STATE MACHINE
+                if self.state in self.DONE_STATES:
+
+                    if self.state == self.STATE_DJPOST:
+                        # display monikas post expression
+                        renpy.show(self.match.postexpress)
+
+                        # hide text
+                        if not self.match.posttext:
+                            self.lyric = None
+
+                        restart_int = True
+
+                        # we go to DPOST instead of POST
+                        self.state = self.STATE_DPOST
+
+                        # force a redraw
+                        renpy.redraw(self, self.vis_timeout)
+
+                    # check for visual timeout
+                    elif st-self.prev_time >= self.vis_timeout:
+
+                        # force event call
+                        self.state = self.STATE_DONE
+                        renpy.timeout(1.0)
+    #                    renpy.redraw(self, 1.0)
+    #                    redrawn = True
+
+                    # do a redraw for the next timeout
+                    else:
+                        renpy.redraw(self, self.vis_timeout)
+    #                    redrawn = True
+
+                elif (
+                        self.state == self.STATE_CLEAN
+                        or st-self.prev_time >= self.ev_timeout
+                    ):
+
+                    # default monika
+                    renpy.show(self.DEFAULT)
+
+                    # hide text
+                    self.lyric = None
+
+                    restart_int = True
+
+                    if self.state not in self.DONE_STATES:
+                        self.state = self.STATE_LISTEN
+                        self.resetVerse()
+                    self.setsongmode(False)
+
+                elif self.state != self.STATE_LISTEN:
+
+                    if self.state == self.STATE_JMATCH:
+
+                        # display monika's expression
+                        renpy.show(self.match.express)
+
+                        # display text
+                        self.lyric = self.match.say
+
+                        # set song mode
+                        self.setsongmode(vis_tout=self.match.vis_timeout)
+
+                        restart_int = True
+                        self.state = self.STATE_MATCH
+
+                    elif self.state == self.STATE_MISS:
+
+                        # display an awkward expresseion monika
+                        renpy.show(self.AWKWARD)
+                        restart_int = True
+
+                    elif self.state == self.STATE_VPOST:
+
+                        # display the post expression
+                        renpy.show(self.lastmatch.postexpress)
+                        restart_int = True
+
+                        # hide text
+                        if not self.lastmatch.posttext:
+                            self.lyric = None
+
+                        # setup visual timeout
+                        if self.lastmatch.vis_timeout:
+    #                        self.customRedraw(
+    #                            self.lastmatch.redraw_time,
+    #                            from_render=True
+    #                        )
+                            renpy.redraw(self, self.lastmatch.vis_timeout)
+                            self.drawn_time = st
+                            self.state = self.STATE_CPOST
+                            redrawn = True
+
+                        else:
+                            self.state = self.STATE_WPOST
+
+                    elif self.state == self.STATE_CPOST:
+
+                        # check if timeout
+                        if st-self.drawn_time >= self.lastmatch.vis_timeout:
+
+                            # display default monika
+                            renpy.show(self.DEFAULT)
+
+                            # hide text
+                            self.lyric = None
+
+                            restart_int = True
+                            self.state = self.STATE_WPOST
+
+                        # force a redraw in a second
+                        else:
+    #                        self.customRedraw(1.0, from_render=True)
+                            renpy.redraw(self, 1.0)
+                            redrawn = True
+
+                    elif self.state == self.STATE_JPOST:
+
+                        # display monikas post expression
+                        renpy.show(self.match.postexpress)
+
+                        # hide text
+                        if not self.match.posttext:
+                            self.lyric = None
+
+                        restart_int = True
+                        self.state = self.STATE_POST
+
+                    elif self.state == self.STATE_FAIL:
+
+                        # display failed monika
+                        renpy.show(self.FAILED)
+
+                        # hide text
+                        self.lyric = None
+
+                        restart_int = True
+                        self.state = self.STATE_CLEAN
+
+                    # redraw timeout
+                    if not redrawn:
+                        renpy.redraw(self, self.vis_timeout)
+    #                    self.customRedraw(self.vis_timeout, from_render=True)
+
+                if self.lyric:
+                    lyric_bar = renpy.render(self.lyrical_bar, 1280, 720, st, at)
+                    lyric = renpy.render(self.lyric, 1280, 720, st, at)
+                    pw, ph = lyric.get_size()
+
+                    # the lyric bar should be slightly below y-center
+                    r.blit(
+                        lyric_bar,
+                        (
+                            0,
+                            int((height - 50) /2) - self.ZZPK_LYR_BAR_YOFF
+                        )
+                    )
+                    r.blit(
+                        lyric,
+                        (
+                            int((width - pw) / 2),
+                            int((height - ph) / 2) - self.ZZPK_LYR_BAR_YOFF
+                        )
+                    )
+
+#                    renpy.show(
+#                        "monika " + match.express,
+#                        at_list=self.AT_LIST,
+#                        zorder=10,
+#                        layer="transient"
+#                    )
+#                    renpy.force_full_redraw()
+#                    r.blit(
+#                        renpy.render(match.img, 1280, 720, st, at),
+#                        (0, 0)
+#                    )
+#                    renpy.say(m, match.say, interact=False)
+#                    renpy.force_full_redraw()
+
+            if restart_int:
+                renpy.restart_interaction()
+
+            # rerender redrawing thing
+            # renpy.redraw(self, 0)
+
+            # and apparenly we return the render object
             return r
 
-
         def event(self, ev, x, y, st):
-            """
-            Event handler for the PianoSetupDisplayable
-            """
+            # renpy event handler
+            # NOTE: Renpy is EVENT-DRIVEN
 
-            # pass all mouse events to the children
-            # TODO: move these to appropraite state checking
             done = self._button_done.event(ev, x, y, st)
             cancel = self._button_cancel.event(ev, x, y, st)
-            if self.state == self.STATE_WAIT:
-                reset = self._button_reset.event(ev, x, y, st)
+
+            if self.state in self.CONFIG_STATES:
+                
+                # configuratrion mode lets go
+                if self.state == self.STATE_CONFIG_WAIT:
+                    # wait stae
+
+                else:
+                    # must be change state
+
             else:
-                reset = self._button_resetall.event(ev, x, y, st)
+                # DONE state means you immediate quit
+                if self.state in self.FINAL_DONE_STATES:
+                    return self.quitflow()
 
-            if ev.type == pygame.KEYDOWN:
-                if ev.key == zzpianokeys.QUIT: # z for now
-                    return 100
-                elif ev.key == pygame.K_q:
-                    self.state = self.STATE_CHANGE
-                elif ev.key == pygame.K_w:
-                    self.state = self.STATE_WAIT
+                # check for config / quit button
+                clicked_config = self._button_config.event(ev, x, y, st)
+                clicked_quit = self._button_config.event(ev, x, y, st)
 
-            # continous event
+                # check for config/quit
+                if clicked_quit is not None:
+                    return self.quitflow()
+
+                elif clicked_config is not None:
+                    self.state = self.STATE_CONFIG_WAIT
+                    # TODO: this state needs to reset you back to default
+                    # expressions, also getting rid of the played list
+
+                else:
+                    # when you press down a key, we launch a sound
+                    if ev.type == pygame.KEYDOWN:
+
+                        # check for mapping
+                        key = persistent.piano_keymaps.get(ev.key, ev.key)
+
+                        if len(self.played) > self.KEY_LIMIT:
+                            self.played = list()
+
+                        # we only care about keydown events regarding timeout
+                        elif st-self.prev_time >= self.ev_timeout:
+
+        #                    self.testing.write("".join([chr(x) for x in self.played])+ "\n")
+                            self.played = list()
+
+                            # NOTE: in the listen state,  timeout means restart
+                            # the played list (which is what handles the note
+                            # matchin). Keep state.
+
+                            # NOTE: in transitional post states, timeout means
+                            # continue waiting.
+                            # Keep state.
+
+                            # NOTE: in done related states, timeout means quit
+                            # the game.
+                            if self.state in self.DONE_STATES:
+                                return self.quitflow()
+
+                            # NOTE: in the match-related states, timeout means
+                            # they failed the expression.
+                            elif self.state in self.TOUT_MATCH_STATES:
+                                self.resetVerse()
+                                self.state = self.STATE_LISTEN
+
+                            # NOTE: in post-match related states, timeout means
+                            # move onto the next expression.
+                            elif self.state in self.TOUT_POST_STATES:
+                                next_pnm = self.getnotematch()
+
+                                if next_pnm:
+                                    self.setsongmode(
+                                        ev_tout=next_pnm.ev_timeout,
+                                        vis_tout=self.match.vis_timeout
+                                    )
+                                    self.state = self.STATE_WPOST
+                                    self.match = next_pnm
+                                    self.match.matchdex = 0
+
+                                # no more matches, we are done
+                                else:
+                                    self.state = self.STATE_WDONE
+
+                            # NOTE: in clean state, chnage state to listen.
+                            elif self.state == self.STATE_CLEAN:
+                                self.state = self.STATE_LISTEN
+
+        #   DEBUG: NOTE:
+        #                if self.match:
+        #                    self.testing.write(
+        #                        chr(ev.key) + " : " + str(self.state) + " : " +
+        #                        str(self.match.matchdex) + "\n")
+        #                else:
+        #                    self.testing.write(chr(ev.key) + " : " + str(self.state) + "\n")
+
+                        # setup previous time thing
+                        self.prev_time = st
+
+                        # only play a sound if we've lifted the finger
+                        if not self.pressed.get(key, True):
+
+                            # note has been hit
+                            self.note_hit = True
+
+                            # add to played
+                            self.played.append(key)
+
+                            # set appropriate value
+                            self.pressed[key] = True
+
+                            # check if we have enough played notes
+                            if self.state == self.STATE_LISTEN:
+                                self.stateListen(ev, key)
+
+                            # post match checking
+                            elif self.state in self.POST_STATES:
+                                self.statePost(ev, key)
+
+                            # waiting post
+                            elif self.state in self.TRANS_POST_STATES:
+                                self.stateWaitPost(ev, key)
+
+                            # match
+                            elif self.state in self.MATCH_STATES:
+                                self.stateMatch(ev, key)
+
+                            # get a sound to play
+                            renpy.play(self.pkeys[key], channel="audio")
+
+                            # now rerender
+    #                        self.customRedraw(0)
+                            renpy.redraw(self, 0)
+
+                    # keyup, means we should stop render
+                    elif ev.type == pygame.KEYUP:
+
+                        # check for mapping
+                        key = persistent.piano_keymaps.get(ev.key, ev.key)
+
+                        # only do this if we keyup a key we care about
+                        if self.pressed.get(key, False):
+
+                            # set appropriate value
+                            self.pressed[key] = False
+
+                            # now rerender
+        #                    self.customRedraw(0)
+                            renpy.redraw(self, 0)
+
+                    # time event, rerender
+                    elif ev.type == renpy.display.core.TIMEEVENT:
+        #                self.customRedraw(0)
+                        renpy.redraw(self, 0)
+
+            # the default so we can keep going
             raise renpy.IgnoreEvent()
+


### PR DESCRIPTION
#885  (and by extension, #858 )

Guess what, friendos. If you were tired of a well-thought out, piano-like key layout that obviously preferred English-typing countries, then worry no more.  Now you can configure each keymap on the piano to your heart's content.

Key features:
1. Piano key keymaps can now be changed in-game. 
2. Buttons (from `MASButtonDisplayable`) have replaced the `Press Z to Quit` label as well as added mouse navigation through the key config process.
3. Keymaps are saved in `persistent` and are set appropriately on Piano launch.
4. The text on the keyboard that tell what key to press dynamically changes depending on your keymap settings.

Here's some fancy pictures:
Keyboard with buttons:
![neatopianobuttons](https://user-images.githubusercontent.com/3499462/36009082-22b33ae8-0d10-11e8-865e-c26ebb31d321.JPG)

Keyboard with custom keylayouts:
![youcannowkeys](https://user-images.githubusercontent.com/3499462/36009093-31cb8b20-0d10-11e8-9c29-3327006c7d9f.png)

To change a key:
1. Click `config`.
2. Click the pink area over the key you want to change.
3. Press the keyboard key you want to set that piano key to.
4. Repeat 3 for all the keys you want.
5. Press `Done`.

Here's some more fancy pictures:
Step 2:
![click_pink](https://user-images.githubusercontent.com/3499462/36009134-78fc3026-0d10-11e8-95b7-ac3b95e42e45.png)

Step 3:
![pressakey](https://user-images.githubusercontent.com/3499462/36009139-7d51a430-0d10-11e8-8419-ddda89ee19fd.png)

The `Reset` button will clear the selected keymap. 
The `Reset All` button clears all the keymaps. 
The `Cancel` will cancel changing the selected keymap.

NOTES:
- There is a blacklist of disallowed key configs. Most of these are weird keys that don't appear on most keyboards or are crucial to actual game functionality (Escape, Print Screen).
- `pygame` equates keycodes with scancodes. This means you can only set the keymaps to keys that are either within the range for `char` types or are in a custom keycode dict I've defined. For a list of these supported ones, check [here](http://www.pygame.org/docs/ref/key.html). Effectively, anything below the Windows keys are **not supported**. (Escape is not supported as well)

Future:
- I could throw in an "Are you sure?" for `Reset All`, but thats probably not needed.