### PR TITLE
Adding programming points for Hair / Clothes / ACS

### DIFF
--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -298,11 +298,11 @@ label autoload:
         jump mas_chess_go_ham_and_delete_everything
 
     # okay lets setup monika's clothes
-    python:
-        monika_chr.change_outfit(
-            persistent._mas_monika_clothes,
-            persistent._mas_monika_hair
-        )
+#    python:
+#        monika_chr.change_outfit(
+#            persistent._mas_monika_clothes,
+#            persistent._mas_monika_hair
+#        )
 
     # need to set the monisize correctly
     $ store.mas_dockstat.setMoniSize(persistent.sessions["total_playtime"])

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1829,6 +1829,8 @@ init -2 python:
             self.img_stand = img_stand
             self.stay_on_start = stay_on_start
             self.pose_map = pose_map
+            self.entry_pp = entry_pp
+            self.exit_pp = exit_pp
 
             if type(pose_map) != MASPoseMap:
                 raise Exception("PoseMap is REQUIRED")
@@ -2338,10 +2340,37 @@ define monika_chr = MASMonika()
 init -2 python in mas_sprites:
     # all progrmaming points should go here
     # organize by type then id
+    # ASSUME all programming points only run at runtime
+    import store
+
+    temp_storage = dict()
+    # all programming points have access to this storage var.
+    # use names + an identifier as keys so you wont collide
+    # NOTE: this will NOT be maintained on a restart
 
     ######### HAIR ###########
 
     ######### CLOTHES ###########
+    def _clothes_rin_entry(_moni_chr):
+        """
+        Entry programming point for rin clothes
+        """
+        temp_storage["clothes.rin"] = store.mas_acs_promisering.pose_map
+        store.mas_acs_promisering.pose_map = store.MASPoseMap(
+            p1=None,
+            p2=None,
+            p3="1",
+            p4=None,
+            p5="5",
+            p6=None
+        )
+
+
+    def _clothes_rin_exit(_moni_chr):
+        """
+        Exit programming point for rin clothes
+        """
+        store.mas_acs_promisering.pose_map = temp_storage["clothes.rin"]
 
     ######### ACS ###########
 
@@ -2488,7 +2517,9 @@ init -1 python:
         fallback=True,
         hair_map={
             "all": "custom"
-        }
+        },
+        entry_pp=store.mas_sprites._clothes_rin_entry,
+        exit_pp=store.mas_sprites._clothes_rin_exit
     )
     store.mas_sprites.init_clothes(mas_clothes_rin)
 


### PR DESCRIPTION
More flexibility with sprites

This adds programming points for all hair / clothes / acs objects

Currently only the rin clothes have programming points, marisa clothes will get them soon.

# Testing
## rin
1. enable and wear promise ring
2. in sprite previewer, switch to rin clothes
3. change poses. verify that pose 2 does not have a ring floating above clothes while pose 3 has a ring.
4. switch clothes to uniform
5. verify that pose 2 has a ring again.
