### PR TITLE
Allow function plugins in season progpoints

### DIFF
--- a/Monika After Story/game/zz_seasons.rpy
+++ b/Monika After Story/game/zz_seasons.rpy
@@ -99,6 +99,12 @@ init -1 python:
 
 init 10 python in mas_seasons:
     import store
+
+    PLUGIN_PP_SPRING = "pp_spring"
+    PLUGIN_PP_SUMMER = "pp_summer"
+    PLUGIN_PP_FALL = "pp_fall"
+    PLUGIN_PP_WINTER = "pp_winter"
+
     # NOTE: all functions here are guaranteed to run at 900, and runtime.
 
     # NOTE: Methodology for seasonal programming points:
@@ -137,7 +143,7 @@ init 10 python in mas_seasons:
         store.mas_consumable_hotchocolate.disable()
 
         #Run spring function plugins
-        store.mas_submod_utils.getAndRunFunctions(key="pp_spring")
+        store.mas_submod_utils.getAndRunFunctions(key=PLUGIN_PP_SPRING)
 
         #NOTE: All things which shouldn't be allowed to be overridden go below the plugins
 
@@ -157,7 +163,7 @@ init 10 python in mas_seasons:
         store.mas_protectedShowEVL("monika_fireworks", "EVE", _random=True)
 
         #Run summer function plugins
-        store.mas_submod_utils.getAndRunFunctions(key="pp_summer")
+        store.mas_submod_utils.getAndRunFunctions(key=PLUGIN_PP_SUMMER)
 
     def _pp_fall():
         """
@@ -167,7 +173,7 @@ init 10 python in mas_seasons:
         store.mas_hideEVL("monika_fireworks", "EVE", derandom=True)
 
         #Run fall function plugins
-        store.mas_submod_utils.getAndRunFunctions(key="pp_fall")
+        store.mas_submod_utils.getAndRunFunctions(key=PLUGIN_PP_FALL)
 
 
     def _pp_winter():
@@ -198,7 +204,7 @@ init 10 python in mas_seasons:
             store.mas_consumable_hotchocolate.enable()
 
         #Run winter function plugins
-        store.mas_submod_utils.getAndRunFunctions(key="pp_winter")
+        store.mas_submod_utils.getAndRunFunctions(key=PLUGIN_PP_WINTER)
 
         #NOTE: All things which shouldn't be allowed to be overridden go below the plugins
         # want to ensure first time we see the islands they are dead and covered in snow


### PR DESCRIPTION
Adds function plugin callers to season prog points for submods

## Testing;
- Verify plugins in these points work
- Verify no crashes

## Added function keys:
- `pp_spring` - Spring progpoint
- `pp_summer` - Summer progpoint
- `pp_fall` - Fall progpoint
- `pp_winter` - Winter progpoint