### PR TITLE
Fix o31 assets paths

### DIFF
--- a/Monika After Story/game/zz_spriteobjects.rpy
+++ b/Monika After Story/game/zz_spriteobjects.rpy
@@ -2294,11 +2294,11 @@ init -1 python:
         "desk_candy_jack",
         ConditionSwitch(
             "(persistent._mas_o31_tt_count + mas_getGiftStatsForDate('mas_reaction_candy', date = mas_o31)) > 2",
-            MASFilterableSprite("mod_assets/monika/a/acs-desk_candy_jack_brim-0.png", None),
+            MASFilterableSprite("mod_assets/monika/a/desk_candy_jack_brim/0.png", None),
             "(persistent._mas_o31_tt_count + mas_getGiftStatsForDate('mas_reaction_candy', date = mas_o31)) > 0",
-            MASFilterableSprite("mod_assets/monika/a/acs-desk_candy_jack_half-0.png", None),
+            MASFilterableSprite("mod_assets/monika/a/desk_candy_jack_half/0.png", None),
             "True",
-            MASFilterableSprite("mod_assets/monika/a/acs-desk_candy_jack_empty-0.png", None)
+            MASFilterableSprite("mod_assets/monika/a/desk_candy_jack_empty/0.png", None)
         ),
         MASPoseMap(
             default=True,
@@ -2319,8 +2319,8 @@ init -1 python:
     mas_acs_desk_lantern = MASDynamicAccessory(
         "desk_lantern",
         ConditionSwitch(
-            "store.mas_isNightNow()", "mod_assets/monika/a/acs-desk_lantern_lit-0.png",
-            "True", MASFilterableSprite("mod_assets/monika/a/acs-desk_lantern_unlit-0.png", None)
+            "store.mas_isNightNow()", "mod_assets/monika/a/desk_lantern_lit/0.png",
+            "True", MASFilterableSprite("mod_assets/monika/a/desk_lantern_unlit/0.png", None)
         ),
         MASPoseMap(
             default=True,


### PR DESCRIPTION
# Problem:
Invalid old paths cause a crash when we show one of the o31 assets

# Fix:
We found 5 lines that point to the files that were moved, we changed the paths to point to the correct locations now.
Affected assets:
- o31 lantern
- o31 pumpkin

# Dropfix:
If people fail to update before the 31, we have to provide this drop fix [0.12.18-dropfix.zip](https://github.com/user-attachments/files/23246018/0.12.18-dropfix.zip)


# Testing:
1. open the game and try to show any of the affected accessories (they are conditional, have multiple sprites)
2. verify no crash