### PR TITLE
Move pre-game quip to a separate opt-in label

### DIFF
--- a/Monika After Story/game/zz_games.rpy
+++ b/Monika After Story/game/zz_games.rpy
@@ -17,7 +17,7 @@ init -10 python in mas_games:
             return platform.system() == 'Windows'
 
 init 1 python in mas_games:
-    def _total_games_played(exclude_list=[]):
+    def _total_games_played(exclude_list=None):
         """
         Returns the total number of games played by adding up the shown_count of each game
 
@@ -26,6 +26,9 @@ init 1 python in mas_games:
                 defaults to an empty list
         """
         global game_db
+
+        if exclude_list is None:
+            exclude_list = []
 
         total_shown_count = 0
         for ev in game_db.values():


### PR DESCRIPTION
As proposed earlier, submitting a change that moves pre-game quip into a separate label so that the game events that are not player vs Monika can choose whether to use it or not.

Unsure if it should be opt-in, though &mdash; maybe making it *opt out* would make more sense in terms of backwards compatibility?