### PR TITLE
Replace 'fa**ot' in script-story-events.rpy with regex pattern

### DIFF
--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -272,7 +272,7 @@ init 3 python:
         "egoist",
         "egotistical",
         "evil",
-        "faggot",
+        r"fag{1,2}ot",
         "failure",
         "fake",
         "fetus",


### PR DESCRIPTION
I would like to add ``fa*ot`` but it's not very good so I added ragex so that both ``fa*ot`` and ``fa**ot`` couldn't be used in nickname